### PR TITLE
server: simplify login error handling and remove non-working redirection to index

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -1,12 +1,12 @@
 package crypto
 
 import (
+	"cerca/util"
 	"crypto/ed25519"
 	crand "crypto/rand"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"cerca/util"
 	"github.com/synacor/argon2id"
 	rand "math/rand"
 )

--- a/database/database.go
+++ b/database/database.go
@@ -1,10 +1,10 @@
 package database
 
 import (
+	"cerca/util"
 	"context"
 	"database/sql"
 	"fmt"
-	"cerca/util"
 	"html/template"
 	"log"
 	"net/url"

--- a/run.go
+++ b/run.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	"cerca/server"
 	"cerca/util"
+	"flag"
+	"fmt"
 	"os"
 	"strings"
 )

--- a/server/server.go
+++ b/server/server.go
@@ -364,7 +364,7 @@ func (h RequestHandler) AboutRoute(res http.ResponseWriter, req *http.Request) {
 }
 
 func (h RequestHandler) RobotsRoute(res http.ResponseWriter, req *http.Request) {
-  fmt.Fprintln(res, "User-agent: *\nDisallow: /")
+	fmt.Fprintln(res, "User-agent: *\nDisallow: /")
 }
 
 func (h RequestHandler) NewThreadRoute(res http.ResponseWriter, req *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -197,14 +197,11 @@ func (h RequestHandler) LoginRoute(res http.ResponseWriter, req *http.Request) {
 		// * hash received password and compare to stored hash
 		passwordHash, userid, err := h.db.GetPasswordHash(username)
 		// make sure user exists
-		if err = ed.Eout(err, "getting password hash and uid"); err != nil {
-			fmt.Println(err)
-			h.renderView(res, "login", TemplateData{LoginData{FailedAttempt: true}, loggedIn, ""})
-			IndexRedirect(res, req)
-			return
+		if err = ed.Eout(err, "getting password hash and uid"); err == nil && !crypto.ValidatePasswordHash(password, passwordHash) {
+			err = errors.New("incorrect password")
 		}
-		if !crypto.ValidatePasswordHash(password, passwordHash) {
-			fmt.Println("incorrect password!")
+		if err != nil {
+			fmt.Println(err)
 			h.renderView(res, "login", TemplateData{LoginData{FailedAttempt: true}, loggedIn, ""})
 			return
 		}

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -27,9 +27,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 import (
+	"cerca/util"
 	"errors"
 	"fmt"
-	"cerca/util"
 	"net/http"
 
 	"github.com/gorilla/sessions"


### PR DESCRIPTION
Not exactly sure why redirection is needed, but it causes `WriteHeader` to be called twice. I removed that.

`gofmt` on top of the PR.