### PR TITLE
Add Date Posted to Threads

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -1,14 +1,17 @@
 package database
 
 import (
-	"cerca/util"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"html/template"
 	"log"
 	"net/url"
+	"os"
 	"time"
+
+	"cerca/util"
 
 	_ "github.com/mattn/go-sqlite3"
 )

--- a/database/database.go
+++ b/database/database.go
@@ -1,10 +1,10 @@
 package database
 
 import (
+	"cerca/util"
 	"context"
 	"database/sql"
 	"fmt"
-	"cerca/util"
 	"html/template"
 	"log"
 	"net/url"
@@ -18,6 +18,14 @@ type DB struct {
 }
 
 func InitDB(filepath string) DB {
+	if _, err := os.Stat(filepath); errors.Is(err, os.ErrNotExist) {
+		file, err := os.Create(filepath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer file.Close()
+	}
+
 	db, err := sql.Open("sqlite3", filepath)
 	util.Check(err, "opening sqlite3 database at %s", filepath)
 	if db == nil {

--- a/html/html.go
+++ b/html/html.go
@@ -1,0 +1,6 @@
+package html
+
+import "embed"
+
+//go:embed *.html
+var templates embed.FS

--- a/html/html.go
+++ b/html/html.go
@@ -2,5 +2,6 @@ package html
 
 import "embed"
 
+// Templates contain the raw HTML of all of our templates.
 //go:embed *.html
-var templates embed.FS
+var Templates embed.FS

--- a/html/thread.html
+++ b/html/thread.html
@@ -2,7 +2,7 @@
     <h2>{{ .Data.Title }}</h2>
     {{ range $index, $post := .Data.Posts }}
     <div>
-        <p><b>{{ $post.Author }}</b> &emdash; {{ $post.Publish | formatDateTime }}</p>
+        <p><b>{{ $post.Author }}</b> &emdash; <time datetime="{{ $post.Publish | formatDateTimeRFC3339 }}">{{ $post.Publish | formatDateTime }}</time></p>
         {{ $post.Content }}
     </div>
     {{ end }}

--- a/html/thread.html
+++ b/html/thread.html
@@ -2,7 +2,7 @@
     <h2>{{ .Data.Title }}</h2>
     {{ range $index, $post := .Data.Posts }}
     <div>
-        <p><b>{{ $post.Author }}</b></p>
+        <p><b>{{ $post.Author }}</b> &emdash; {{ $post.Publish | formatDateTime }}</p>
         {{ $post.Content }}
     </div>
     {{ end }}

--- a/run.go
+++ b/run.go
@@ -3,10 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"cerca/server"
-	"cerca/util"
 	"os"
 	"strings"
+
+	"cerca/server"
+	"cerca/util"
 )
 
 func readAllowlist(location string) []string {

--- a/server/server.go
+++ b/server/server.go
@@ -103,13 +103,24 @@ func wrapViews() []string {
 	return views
 }
 
-var templates = template.Must(template.ParseFiles(wrapViews()...))
+var (
+	templates     = template.Must(template.ParseFiles(wrapViews()...))
+	templateFuncs = template.FuncMap{
+		"formatDateTime": func(dt time.Time) string {
+			return t.Format(time.RFC3339)
+		},
+		"formatDate": func(dt time.Time) string {
+			return t.Format("2006-01-02")
+		},
+	}
+)
 
 func (h RequestHandler) renderView(res http.ResponseWriter, viewName string, data TemplateData) {
 	if data.Title == "" {
 		data.Title = strings.ReplaceAll(viewName, "-", " ")
 	}
-	errTemp := templates.ExecuteTemplate(res, viewName+".html", data)
+
+	errTemp := templates.Funcs(templateFuncs).ExecuteTemplate(res, viewName+".html", data)
 	if errors.Is(errTemp, syscall.EPIPE) {
 		fmt.Println("had a broken pipe, continuing")
 	} else {

--- a/server/server.go
+++ b/server/server.go
@@ -107,7 +107,10 @@ var (
 	templates     = template.Must(template.ParseFiles(wrapViews()...))
 	templateFuncs = template.FuncMap{
 		"formatDateTime": func(dt time.Time) string {
-			return t.Format(time.RFC3339)
+			return t.Format("2006-01-02 15:04:05")
+		},
+		"formatDateTimeRFC3339": func(dt time.Time) string {
+			return t.Format(time.RFC3339Nano)
 		},
 		"formatDate": func(dt time.Time) string {
 			return t.Format("2006-01-02")

--- a/server/server.go
+++ b/server/server.go
@@ -107,8 +107,8 @@ var (
 )
 
 func (h RequestHandler) renderView(res http.ResponseWriter, viewName string, data TemplateData) {
-	view := viewName + ".html"
-	tpl, err := template.New(view).Funcs(templateFuncs).ParseFile(view)
+	view := fmt.Sprintf("html/%s.html", viewName)
+	tpl, err := template.New(view).Funcs(templateFuncs).ParseFiles(view)
 	if err != nil {
 		util.Check(err, "parsing %q view", view)
 	}
@@ -117,8 +117,8 @@ func (h RequestHandler) renderView(res http.ResponseWriter, viewName string, dat
 		data.Title = strings.ReplaceAll(viewName, "-", " ")
 	}
 
-	if err := t.ExecuteTemplate(res, viewName+".html", data); err != nil {
-		util.Check(errTemp, "rendering %s view", viewName)
+	if err := tpl.ExecuteTemplate(res, view, data); err != nil {
+		util.Check(err, "rendering %q view", view)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html/template"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"cerca/crypto"
 	"cerca/database"
 	"cerca/server/session"
 	"cerca/util"
-	"html/template"
 
 	"github.com/carlmjohnson/requests"
 )
@@ -106,13 +107,13 @@ func wrapViews() []string {
 var (
 	templates     = template.Must(template.ParseFiles(wrapViews()...))
 	templateFuncs = template.FuncMap{
-		"formatDateTime": func(dt time.Time) string {
+		"formatDateTime": func(t time.Time) string {
 			return t.Format("2006-01-02 15:04:05")
 		},
-		"formatDateTimeRFC3339": func(dt time.Time) string {
+		"formatDateTimeRFC3339": func(t time.Time) string {
 			return t.Format(time.RFC3339Nano)
 		},
-		"formatDate": func(dt time.Time) string {
+		"formatDate": func(t time.Time) string {
 			return t.Format("2006-01-02")
 		},
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -109,7 +109,7 @@ var (
 
 func (h RequestHandler) renderView(res http.ResponseWriter, viewName string, data TemplateData) {
 	view := fmt.Sprintf("html/%s.html", viewName)
-	tpl, err := template.New(view).Funcs(templateFuncs).ParseFS(html.templates)
+	tpl, err := template.New(view).Funcs(templateFuncs).ParseFS(html.Templates)
 	if err != nil {
 		util.Check(err, "parsing views")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"cerca/crypto"
 	"cerca/database"
+	"cerca/html"
 	"cerca/server/session"
 	"cerca/util"
 
@@ -108,9 +109,9 @@ var (
 
 func (h RequestHandler) renderView(res http.ResponseWriter, viewName string, data TemplateData) {
 	view := fmt.Sprintf("html/%s.html", viewName)
-	tpl, err := template.New(view).Funcs(templateFuncs).ParseFiles(view)
+	tpl, err := template.New(view).Funcs(templateFuncs).ParseFS(html.templates)
 	if err != nil {
-		util.Check(err, "parsing %q view", view)
+		util.Check(err, "parsing views")
 	}
 
 	if data.Title == "" {

--- a/server/server.go
+++ b/server/server.go
@@ -367,7 +367,7 @@ func (h RequestHandler) AboutRoute(res http.ResponseWriter, req *http.Request) {
 }
 
 func (h RequestHandler) RobotsRoute(res http.ResponseWriter, req *http.Request) {
-  fmt.Fprintln(res, "User-agent: *\nDisallow: /")
+	fmt.Fprintln(res, "User-agent: *\nDisallow: /")
 }
 
 func (h RequestHandler) NewThreadRoute(res http.ResponseWriter, req *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -2,14 +2,12 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"html/template"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"cerca/crypto"


### PR DESCRIPTION
Been a while since I've messed with Go's template parsing using standard lib :D 

 - Adds datetime functions for templates
 - Moves templates into the compiled binary, so the binary can be distributed without the html folder
 - Some small style fixes from my Go parser in my IDE
 - Creates an empty data folder and file creation check to make testing for others easier in the future