### PR TITLE
Posts refs

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -262,11 +262,12 @@ func (d DB) ListThreads() []Thread {
 	return threads
 }
 
-func (d DB) AddPost(content string, threadid, authorid int) {
-	stmt := `INSERT INTO posts (content, publishtime, threadid, authorid) VALUES (?, ?, ?, ?)`
+func (d DB) AddPost(content string, threadid, authorid int) (postID int) {
+	stmt := `INSERT INTO posts (content, publishtime, threadid, authorid) VALUES (?, ?, ?, ?) RETURNING id`
 	publish := time.Now()
-	_, err := d.Exec(stmt, content, publish, threadid, authorid)
+	err := d.db.QueryRow(stmt, content, publish, threadid, authorid).Scan(&postID)
 	util.Check(err, "add post to thread %d (author %d)", threadid, authorid)
+	return
 }
 
 func (d DB) EditPost(content string, postid int) {

--- a/html/about.html
+++ b/html/about.html
@@ -36,6 +36,9 @@
         <p>Create links like <code>[this](url)</code>, and embed images like: <code>![description](url)</code>. Note how the image
         syntax's exclamation mark precedes the regular link syntax.</p>
 
+        <p>Each post in the thread can be referenced like <code>[this post](#12)</code>, where 12 is the post number which can be
+        found at each post timestamp.</p>
+
         <pre><code>this is one paragraph.
         this belongs to the same paragraph.
 

--- a/html/thread.html
+++ b/html/thread.html
@@ -5,7 +5,7 @@
     {{ $threadURL := .Data.ThreadURL }}
     {{ range $index, $post := .Data.Posts }}
     <article>
-        <div>
+        <div id="{{ $post.ID }}">
             {{ if eq $post.AuthorID $userID }} 
                 <span style="float: right;" aria-label="Delete this post">
                     <form style="display: inline-block;" method="POST" action="/post/delete/{{ $post.ID }}"
@@ -18,10 +18,13 @@
             {{ end }}
             <p>
             <span><b>{{ $post.Author }}</b>
-                <span class="visually-hidden"> responded:</span></span>
-            <span style="margin-left: 0.5rem; font-style: italic;">
-                <time datetime="{{ $post.Publish | formatDate }}">{{ $post.Publish | formatDateRelative }}</time>
+                <span class="visually-hidden"> responded:</span>
             </span>
+            <a href="#{{ $post.ID }}">
+                <span style="margin-left: 0.5rem; font-style: italic;">
+                    <time datetime="{{ $post.Publish | formatDate }}">{{ $post.Publish | formatDateRelative }}</time>
+                </span>
+            </a>
             </p>
             {{ $post.Content }}
     </article>

--- a/server/server.go
+++ b/server/server.go
@@ -179,8 +179,8 @@ func (h RequestHandler) ThreadRoute(res http.ResponseWriter, req *http.Request) 
 		// TODO (2022-01-09): make sure rendered content won't be empty after sanitizing:
 		// * run sanitize step && strings.TrimSpace and check length **before** doing AddPost
 		// TODO(2022-01-09): send errors back to thread's posting view
-		h.db.AddPost(content, threadid, userid)
-		http.Redirect(res, req, req.URL.Path, http.StatusSeeOther)
+		postID := h.db.AddPost(content, threadid, userid)
+		http.Redirect(res, req, fmt.Sprintf("%s#%d", req.URL.Path, postID), http.StatusFound)
 		return
 	}
 	// TODO (2022-01-07):


### PR DESCRIPTION
* each thread post has an `id` and `href` on the timestamp, for easier referencing (`See [this one](#r123)` in a post to reference another post, for example)
* creating a post redirects to _it_, instead of the start of the thread