### PR TITLE
Fix Textarea width while keeping responsive

### DIFF
--- a/html/head.html
+++ b/html/head.html
@@ -67,7 +67,17 @@
                 user-select: all;
             }
             pre { overflow: auto; }
-            .post-container { display: grid; max-width: 30rem; margin-top: 1rem; }
+
+            .post-container {
+                max-width: 30rem;
+                margin-top: 1rem;
+            }
+            .post-container > * {
+                display: block;
+            }
+            .post-container textarea {
+                width: 100%;
+            }
             body { padding: 2rem; background: wheat; }
             * { margin-bottom: 1rem; }
 

--- a/html/head.html
+++ b/html/head.html
@@ -74,10 +74,9 @@
             }
             .post-container > * {
                 display: block;
-            }
-            .post-container textarea {
                 width: 100%;
             }
+
             body { padding: 2rem; background: wheat; }
             * { margin-bottom: 1rem; }
 


### PR DESCRIPTION
The `post-container` class is a grid parent. A browser that does not support grid default to a block container and the children to inline-block, thus causing the textarea and button being side by side on netsurf.

This PR turns post-container removes grid and makes the children block everything flows vertically, and adds width 100% to textearea so it stays responsive.

![textarea all](https://user-images.githubusercontent.com/8302525/149406374-2005eb25-0f14-490a-a152-0c7f8e7ea319.png)


