### PR TITLE
Add a rudimentary logger and convert logging calls across codebase

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,44 @@
+package logger
+
+import (
+	"log"
+)
+
+type LogLevel uint32
+
+const (
+	LevelFatal LogLevel = iota
+	LevelError
+	LevelInfo
+	LevelDebug
+)
+
+var globalLevel = LevelInfo
+
+func SetLevel(level LogLevel) {
+	globalLevel = level
+}
+
+func Fatal(format string, v ...interface{}) {
+	if globalLevel >= LevelFatal {
+		log.Fatalf("[FATAL] "+format, v...)
+	}
+}
+
+func Error(format string, v ...interface{}) {
+	if globalLevel >= LevelError {
+		log.Printf("[ERROR] "+format, v...)
+	}
+}
+
+func Info(format string, v ...interface{}) {
+	if globalLevel >= LevelInfo {
+		log.Printf("[INFO] "+format, v...)
+	}
+}
+
+func Debug(format string, v ...interface{}) {
+	if globalLevel >= LevelDebug {
+		log.Printf("[DEBUG] "+format, v...)
+	}
+}

--- a/run.go
+++ b/run.go
@@ -2,18 +2,18 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 
+	"cerca/logger"
 	"cerca/server"
-	"cerca/util"
 )
 
 func readAllowlist(location string) []string {
-	ed := util.Describe("read allowlist")
 	data, err := os.ReadFile(location)
-	ed.Check(err, "read file")
+	if err != nil {
+		logger.Fatal("failed to read allowlist at %s: %v", location, err)
+	}
 	list := strings.Split(strings.TrimSpace(string(data)), "\n")
 	for i, fullpath := range list {
 		list[i] = strings.TrimPrefix(strings.TrimPrefix(fullpath, "https://"), "http://")
@@ -22,7 +22,7 @@ func readAllowlist(location string) []string {
 }
 
 func complain(msg string) {
-	fmt.Printf("cerca: %s\n", msg)
+	logger.Info("cerca: %s\n", msg)
 	os.Exit(0)
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -1,68 +1,13 @@
 package util
 
 import (
-	"fmt"
 	"html/template"
-	"log"
 	"net/url"
 	"strings"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/microcosm-cc/bluemonday"
-	// "errors"
 )
-
-/* util.Eout example invocations
-if err != nil {
-  return util.Eout(err, "reading data")
-}
-if err = util.Eout(err, "reading data"); err != nil {
-  return nil, err
-}
-*/
-
-type ErrorDescriber struct {
-	environ string // the basic context that is potentially generating errors (like a GetThread function, the environ would be "get thread")
-}
-
-// parametrize Eout/Check such that error messages contain a defined context/environ
-func Describe(environ string) ErrorDescriber {
-	return ErrorDescriber{environ}
-}
-
-func (ed ErrorDescriber) Eout(err error, msg string, args ...interface{}) error {
-	msg = fmt.Sprintf("%s: %s", ed.environ, msg)
-	return Eout(err, msg, args...)
-}
-
-func (ed ErrorDescriber) Check(err error, msg string, args ...interface{}) {
-	msg = fmt.Sprintf("%s: %s", ed.environ, msg)
-	Check(err, msg, args...)
-}
-
-// format all errors consistently, and provide context for the error using the string `msg`
-func Eout(err error, msg string, args ...interface{}) error {
-	if err != nil {
-		// received an invocation of e.g. format:
-		// Eout(err, "reading data for %s and %s", "database item", "weird user")
-		if len(args) > 0 {
-			return fmt.Errorf("%s (%w)", fmt.Sprintf(msg, args...), err)
-		}
-		return fmt.Errorf("%s (%w)", msg, err)
-	}
-	return nil
-}
-
-func Check(err error, msg string, args ...interface{}) {
-	if len(args) > 0 {
-		err = Eout(err, msg, args...)
-	} else {
-		err = Eout(err, msg)
-	}
-	if err != nil {
-		log.Fatalln(err)
-	}
-}
 
 func Contains(slice []string, s string) bool {
 	for _, item := range slice {


### PR DESCRIPTION
This creates a rudimentary logger that can then be used across the codebase and cleans up some of the existing calls. I'd love some input as to what you think about this and whether this aligns with your approach. I'm more than happy to not go down this route if it doesn't make sense!

In particular, this removes some of the error context code in favour of a flatter model, which I realise is a larger change that is worth confirming the value of.