### PR TITLE
adds an object implementing http.ServeMux to allow for use with alternate listeners(TLS, Onion, I2P, etc)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -696,6 +696,10 @@ func Serve(allowlist []string, sessionKey string, isdev bool) {
 	http.ListenAndServe(port, nil)
 }
 
+// CercaForum is an HTTP.ServeMux which is set up to initialize and run
+// a cerca-based forum. Software developers who wish to customize the
+// networks and security which they use to operate may wish to use this
+// to listen with TLS, Onion, or I2P addresses without manual setup.
 type CercaForum struct {
 	http.ServeMux
 	Directory string
@@ -713,6 +717,9 @@ func (u *CercaForum) directory() string {
 	return u.Directory
 }
 
+// NewServer sets up a new CercaForum object. Always use this to initialize
+// new CercaForum objects. Pass the result to http.Serve() with your choice
+// of net.Listener.
 func NewServer(allowlist []string, sessionKey string) (*CercaForum, error) {
 	s := &CercaForum{
 		ServeMux: http.ServeMux{},

--- a/server/server.go
+++ b/server/server.go
@@ -707,7 +707,7 @@ func (u *CercaForum) directory() string {
 		if err != nil {
 			log.Fatal(err)
 		}
-		u.Directory = filepath.Join(dir, "UncivServer")
+		u.Directory = filepath.Join(dir, "CercaForum")
 	}
 	os.MkdirAll(u.Directory, 0755)
 	return u.Directory


### PR DESCRIPTION
This allows cerca to be used as a "library" of sorts which a user embeds in their own system and deploys with an alternate set of assets. That way, people who want to can set up a listener which uses different forms of cryptography with different properties to protect the content that they are viewing, and easily set up .onion and .i2p versions of cerca forums.