### PR TITLE
implement basic categories support for thread index

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -4,6 +4,7 @@ import (
 	"cerca/crypto"
 	"context"
 	"database/sql"
+	"regexp"
 	"errors"
 	"fmt"
 	"log"
@@ -301,8 +302,18 @@ type Thread struct {
 	Slug    string
 	Private bool
 	ID      int
+	Show		bool // whether to show the thread in the thread index or not
 	Publish time.Time
 	PostID  int
+}
+
+var categoryPattern = regexp.MustCompile(`\[(.*?)\]`)
+func (t Thread) GetCategory () string {
+	matches := categoryPattern.FindStringSubmatch(t.Title)
+	if matches == nil { 
+		return "no category"
+	}
+	return matches[1]
 }
 
 // get a list of threads

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cblgh/plain v0.0.0-20220516113423-253f690e4083
 	github.com/gomarkdown/markdown v0.0.0-20211212230626-5af6ad2f47df
 	github.com/gorilla/sessions v1.2.1
+	github.com/jinzhu/inflection v1.0.0
 	github.com/komkom/toml v0.1.2
 	github.com/matthewhartstonge/argon2 v1.0.0
 	github.com/mattn/go-sqlite3 v1.14.19

--- a/html/index.html
+++ b/html/index.html
@@ -3,11 +3,22 @@
     {{ if len .Data.Threads | eq 0 }} 
     <p> There are currently no threads. </p>
     {{ end }}
+    <form type="GET" action="/?show">
+    {{ $categoryMap := index .Data.URLParamsCategories }}
+    {{ range $index, $category := .Data.Categories}}
+        {{ $categoryUrlParamSet := index $categoryMap $category }}
+        <input type="checkbox" id="filter-{{$category}}" {{ if $categoryUrlParamSet }} checked {{ end }} value="{{ $category }}" name="show"/>
+        <label style="display: inline-block;" for="filter-{{$category}}">{{ $category }}</label>
+    {{ end }}
+    <button type="submit">filter</button>
+    </form>
     {{ range $index, $thread := .Data.Threads }}
-    <h2>
-      <a href="{{$thread.Slug}}">{{ $thread.Title }}</a>
-      {{ if $thread.Private }} <span title='{{ "Private" | translate }}'>⚿</span> {{ end }}
-    </h2>
+        {{ if $thread.Show }}
+        <h2>
+          <a href="{{$thread.Slug}}">{{ $thread.Title }}</a>
+        {{ if $thread.Private }} <span title='{{ "Private" | translate }}'>⚿</span> {{ end }}
+        </h2>
+        {{ end }}
     {{ end }}
 </main>
 {{ if .LoggedIn }}


### PR DESCRIPTION
this feature has been discussed previously:

* https://github.com/cblgh/cerca/issues/81#issuecomment-2423100504
* https://forum.merveilles.town/thread/94/diving-into-thread-categories-9/

![2024-11-19-164124_1920x1080_scrot](https://github.com/user-attachments/assets/473c013a-f449-4a9a-aa74-c62d1b5f6069)

a category is defined as the first bracketed string that can be found in a thread title, e.g. `[events] cerca dev circle`.

to mitigate the proliferation of multiple tags for the same category, the category names are inflected to only represent it in singular form: events -> event