### PR TITLE
Add invites functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ cerca --help
 USAGE:
   run the forum
 
-  cerca -allowlist allow.txt -authkey "CHANGEME"
-  cerca -dev
+    cerca -authkey "CHANGEME"
+    cerca -dev
 
 COMMANDS:
   adduser    create a new user
@@ -42,8 +42,6 @@ COMMANDS:
   resetpw    reset a user's password
 
 OPTIONS:
-  -allowlist string
-        domains which can be used to read verification codes from during registration
   -authkey string
         session cookies authentication key
   -config string
@@ -64,7 +62,7 @@ cerca adduser --username "<username>"
 Cerca supports community customization.
 
 * Write a custom [about text](/defaults/sample-about.md) describing the community inhabiting the forum
-* Define your own [registration rules](/defaults/sample-rules.md), [how to verify one's account](/defaults/sample-verification-instructions.md), and link to an existing code of conduct
+* Define your own [registration rules](/defaults/sample-rules.md), [instructions on getting an invite code to register](/defaults/sample-registration-instructions.md), and link to an existing code of conduct
 * Set your own [custom logo](/defaults/sample-logo.html) (whether svg, png or emoji)
 * Create your own theme by writing plain, frameworkless [css](/html/assets/theme.css)
 
@@ -93,7 +91,7 @@ forum_url = "" # should be forum index route https://example.com. used to genera
 logo =  "content/logo.html" # can contain emoji, <img>, <svg> etc. see defaults/sample-logo.html in repo for instructions
 about = "content/about.md"
 rules = "content/rules.md"
-verification_instructions = "content/verification-instructions.md"
+registration_instructions = "content/registration-instructions.md"
 ```
 
 Content documents that are not found will be prepopulated using Cerca's [sample content

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It was written for the purpose of powering the nascent [Merveilles community for
 * **Customizable**: Many of Cerca's facets are customizable and the structure is intentionally simple to enable DIY modification
 * **Private**: Threads are public viewable by default but new threads may be set as private, restricting views to logged-in users only
 * **Easy admin**: A simple admin panel lets you add users, reset passwords, and remove old accounts. Impactful actions require two admins to perform, or a week of time to pass without a veto from any admin
+* **Invites**: Fully-featured system for creating invites both one-time and reusable invites. Admins can monitor invite redemption by batch as well as issue and delete batches of invites. Accessible using the same simple type of web interface that services the rest of the forum's administration tasks.
 * **Transparency**: Actions taken by admins are viewable by any logged-in user in the form of a moderation log
 * **Low maintenance**: Cerca is architected to minimize maintenance and hosting costs by carefully choosing which features it supports, how they work, and which features are intentionally omitted
 * **RSS**: Receive updates when threads are created or new posts are made by subscribing to the forum RSS feed

--- a/cmd/cerca/main.go
+++ b/cmd/cerca/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
@@ -45,22 +44,6 @@ func usage(help string, fset *flag.FlagSet) {
 	flag.PrintDefaults()
 }
 
-func readAllowlist(location string) []string {
-	ed := util.Describe("read allowlist")
-	data, err := os.ReadFile(location)
-	ed.Check(err, "read file")
-	list := strings.Split(strings.TrimSpace(string(data)), "\n")
-	var processed []string
-	for _, fullpath := range list {
-		u, err := url.Parse(fullpath)
-		if err != nil {
-			continue
-		}
-		processed = append(processed, u.Host)
-	}
-	return processed
-}
-
 func inform(msg string, args ...interface{}) {
 	if len(args) > 0 {
 		fmt.Printf("%s\n", fmt.Sprintf(msg, args...))
@@ -79,21 +62,18 @@ func complain(msg string, args ...interface{}) {
 }
 
 func run() {
-	// TODO (2022-01-10): somehow continually update veri sites by scraping merveilles webring sites || webring domain
-	var allowlistLocation string
 	var sessionKey string
 	var configPath string
 	var dataDir string
 	var dev bool
 
 	flag.BoolVar(&dev, "dev", false, "trigger development mode")
-	flag.StringVar(&allowlistLocation, "allowlist", "", "domains which can be used to read verification codes from during registration")
 	flag.StringVar(&sessionKey, "authkey", "", "session cookies authentication key")
 	flag.StringVar(&configPath, "config", "cerca.toml", "config and settings file containing cerca's customizations")
 	flag.StringVar(&dataDir, "data", "./data", "directory where cerca will dump its database")
 
 	help := createHelpString("run", []string{
-		"cerca -allowlist allow.txt -authkey \"CHANGEME\"",
+		"cerca -authkey \"CHANGEME\"",
 		"cerca -dev",
 	})
 	flag.Usage = func() { usage(help, nil) }
@@ -110,28 +90,13 @@ func run() {
 		}
 		sessionKey = "0"
 	}
-	if len(allowlistLocation) == 0 {
-		if !dev {
-			complain("please pass a file containing the verification code domain allowlist")
-		}
-		allowlistLocation = "temp-allowlist.txt"
-		created, err := util.CreateIfNotExist(allowlistLocation, "")
-		if err != nil {
-			complain(fmt.Sprintf("couldn't create %s: %s", allowlistLocation, err))
-		}
-		if created {
-			fmt.Println(fmt.Sprintf("Created %s", allowlistLocation))
-		}
-	}
 
 	err := os.MkdirAll(dataDir, 0750)
 	if err != nil {
 		complain(fmt.Sprintf("couldn't create dir '%s'", dataDir))
 	}
-	allowlist := readAllowlist(allowlistLocation)
-	allowlist = append(allowlist, "merveilles.town")
 	config := util.ReadConfig(configPath)
-	server.Serve(allowlist, sessionKey, dev, dataDir, config)
+	server.Serve(sessionKey, dev, dataDir, config)
 }
 
 func main() {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -13,6 +13,8 @@ const (
 	MODLOG_ADMIN_PROPOSE_DEMOTE_ADMIN
 	MODLOG_ADMIN_PROPOSE_MAKE_ADMIN
 	MODLOG_ADMIN_PROPOSE_REMOVE_USER
+	MODLOG_CREATE_INVITE_BATCH
+	MODLOG_DELETE_INVITE_BATCH
 	/* NOTE: when adding new values, only add them after already existing values! otherwise the existing variables will
 	* receive new values which affects the stored values in table moderation_log */
 )

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -2,11 +2,9 @@ package crypto
 
 import (
 	"cerca/util"
-	crand "crypto/rand"
-	"encoding/binary"
+	"crypto/rand"
 	"github.com/matthewhartstonge/argon2"
 	"math/big"
-	rand "math/rand"
 	"strings"
 )
 
@@ -41,32 +39,10 @@ func GeneratePassword() string {
 
 	for i := 0; i < pwlength; i++ {
 		max := big.NewInt(maxChar)
-		bigN, err := crand.Int(crand.Reader, max)
+		bigN, err := rand.Int(rand.Reader, max)
 		util.Check(err, "randomly generate int")
 		n := bigN.Int64()
 		password.WriteString(string(characterSet[n]))
 	}
 	return password.String()
-}
-
-func GenerateVerificationCode() int {
-	var src cryptoSource
-	rnd := rand.New(src)
-	return rnd.Intn(999999)
-}
-
-type cryptoSource struct{}
-
-func (s cryptoSource) Seed(seed int64) {}
-
-func (s cryptoSource) Int63() int64 {
-	return int64(s.Uint64() & ^uint64(1<<63))
-}
-
-func (s cryptoSource) Uint64() (v uint64) {
-	err := binary.Read(crand.Reader, binary.BigEndian, &v)
-	if err != nil {
-		util.Check(err, "generate random verification code")
-	}
-	return v
 }

--- a/database/database.go
+++ b/database/database.go
@@ -526,15 +526,15 @@ func (d DB) GetSystemUserid() int {
 	return systemUserid
 }
 
-func (d DB) AddRegistration(userid int, verificationLink string) error {
+func (d DB) AddRegistration(userid int, registrationOrigin string) error {
 	ed := util.Describe("add registration")
 	stmt := `INSERT INTO registrations (userid, host, link, time) VALUES (?, ?, ?, ?)`
 	t := time.Now()
-	u, err := url.Parse(verificationLink)
+	u, err := url.Parse(registrationOrigin)
 	if err = ed.Eout(err, "parse url"); err != nil {
 		return err
 	}
-	_, err = d.Exec(stmt, userid, u.Host, verificationLink, t)
+	_, err = d.Exec(stmt, userid, u.Host, registrationOrigin, t)
 	if err = ed.Eout(err, "add registration"); err != nil {
 		return err
 	}

--- a/database/database.go
+++ b/database/database.go
@@ -132,6 +132,7 @@ func createTables(db *sql.DB) {
 		label TEXT,
 		adminid INTEGER NOT NULL,
 		time DATE NOT NULL,
+		reusable BOOL NOT NULL,
 
 		FOREIGN KEY(adminid) REFERENCES users(id)
 	);

--- a/database/database.go
+++ b/database/database.go
@@ -124,7 +124,19 @@ func createTables(db *sql.DB) {
 		FOREIGN KEY (recipientid) REFERENCES users(id)
 	);
 		`,
-		`
+	`
+	CREATE TABLE IF NOT EXISTS invites (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		batchid TEXT NOT NULL, -- uuid v4
+		invite TEXT NOT NULL,
+		label TEXT,
+		adminid INTEGER NOT NULL,
+		time DATE NOT NULL,
+
+		FOREIGN KEY(adminid) REFERENCES users(id)
+	);
+	`,	
+	`
   CREATE TABLE IF NOT EXISTS registrations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     userid INTEGER,

--- a/database/moderation.go
+++ b/database/moderation.go
@@ -445,14 +445,14 @@ func (d DB) AddAdmin(userid int) error {
 	// make sure the id exists
 	exists, err := d.CheckUserExists(userid)
 	if !exists {
-		return errors.New(fmt.Sprintf("add admin: userid %d did not exist", userid))
+		return fmt.Errorf("add admin: userid %d did not exist", userid)
 	}
 	if err != nil {
 		return ed.Eout(err, "CheckUserExists had an error")
 	}
 	isAdminAlready, err := d.IsUserAdmin(userid)
 	if isAdminAlready {
-		return errors.New(fmt.Sprintf("userid %d was already an admin", userid))
+		return fmt.Errorf("userid %d was already an admin", userid)
 	}
 	if err != nil {
 		// some kind of error, let's bubble it up
@@ -472,14 +472,14 @@ func (d DB) DemoteAdmin(userid int) error {
 	// make sure the id exists
 	exists, err := d.CheckUserExists(userid)
 	if !exists {
-		return errors.New(fmt.Sprintf("demote admin: userid %d did not exist", userid))
+		return fmt.Errorf("demote admin: userid %d did not exist", userid)
 	}
 	if err != nil {
 		return ed.Eout(err, "CheckUserExists had an error")
 	}
 	isAdmin, err := d.IsUserAdmin(userid)
 	if !isAdmin {
-		return errors.New(fmt.Sprintf("demote admin: userid %d was not an admin", userid))
+		return fmt.Errorf("demote admin: userid %d was not an admin", userid)
 	}
 	if err != nil {
 		// some kind of error, let's bubble it up
@@ -625,12 +625,12 @@ func (d DB) CreateInvites (adminid int, amount int, label string) error {
   }
 
   if !isAdmin {
-		return errors.New(fmt.Sprintf("userid %d was not an admin, they can't create an invite", adminid))
+		return fmt.Errorf("userid %d was not an admin, they can't create an invite", adminid)
   }
 
   // check that amount is within reasonable range
   if amount > maxBatchAmount {
-		return errors.New(fmt.Sprintf("batch amount should not exceed %d but was %d; not creating invites ", maxBatchAmount, amount))
+		return fmt.Errorf("batch amount should not exceed %d but was %d; not creating invites ", maxBatchAmount, amount)
   }
 
   // check that already existing unclaimed invites is within a reasonable range
@@ -640,7 +640,7 @@ func (d DB) CreateInvites (adminid int, amount int, label string) error {
 	ed.Check(err, "querying for number of unclaimed invites")
   if unclaimed > maxUnclaimedAmount {
 		msgstr := "number of unclaimed invites amount should not exceed %d but was %d; ceasing invite creation"
-		return errors.New(fmt.Sprintf(msgstr, maxUnclaimedAmount, unclaimed))
+		return fmt.Errorf(msgstr, maxUnclaimedAmount, unclaimed)
   }
 
   // all cleared!
@@ -654,7 +654,7 @@ func (d DB) CreateInvites (adminid int, amount int, label string) error {
   }
 
   if amount <= 0 {
-		return errors.New(fmt.Sprintf("number of unclaimed invites amount %d has been reached; not creating invites ", maxUnclaimedAmount))
+		return fmt.Errorf("number of unclaimed invites amount %d has been reached; not creating invites ", maxUnclaimedAmount)
   }
 
   creationTime := time.Now()

--- a/database/moderation.go
+++ b/database/moderation.go
@@ -535,6 +535,15 @@ type InviteBatch struct {
 	CreationTime  time.Time
 }
 
+// by admin+creationTime
+/*
+* get all invites -> returns []InviteBatch 
+* map[username+string(creationTime]InviteBatch
+* iterate over the map
+*		-> collect creation time
+*   -> sort by time, newest first?
+*/
+
 // TODO (2024-11-22): consider d1's request of invites that are repeat-redeemable until deleted by an admin
 func (d DB) ClaimInvite (invite string) (finalErr error) {
   ed := util.Describe("claim invite")
@@ -581,6 +590,7 @@ func (d DB) ClaimInvite (invite string) (finalErr error) {
   finalErr = nil
   return 
 }
+
 const maxBatchAmount = 100
 const maxUnclaimedAmount = 500
 
@@ -639,7 +649,12 @@ func DestroyInvites (invites []string, adminid int) (bool, error) {
 }
 
 func GetInvitesByLabel(label string) []string {
-		var invites []string
-    // SELECT * FROM invites where label = ?
-    return invites
-		}
+	var invites []string
+	// SELECT * FROM invites where label = ?
+	return invites
+}
+
+func GetAllInvites() []InviteBatch {
+	var batches []InviteBatch
+	query := "SELECT u.username i. FROM invites i INNER JOIN users u on i.adminid = u.id"
+}

--- a/database/moderation.go
+++ b/database/moderation.go
@@ -540,20 +540,6 @@ type InviteBatch struct {
 	Reusable bool
 }
 
-// by admin+creationTime
-/*
-* get all invites -> returns []InviteBatch 
-* map[username+string(creationTime]InviteBatch
-* iterate over the map
-*		-> collect creation time
-*   -> sort by time, newest first?
-*/
-
-// TODO (2024-11-22): consider d1's request of invites that are repeat-redeemable until deleted by an admin
-// returns: 
-// * a bool signaling whether the invite was successfully claimed or not
-// * a string representing the batchid associated with this invite
-// * an error, nil if everything went according to expectations (either claimed invite, or invite code was not valid)
 func (d DB) ClaimInvite (invite string) (bool, string, error) {
   ed := util.Describe("claim invite")
   var err error
@@ -625,16 +611,6 @@ func (d DB) ClaimInvite (invite string) (bool, string, error) {
 }
 
 
-// CREATE TABLE IF NOT EXISTS invites (
-// id INTEGER PRIMARY KEY AUTOINCREMENT,
-// batchid TEXT NOT NULL, -- this is a uuid v4
-// invite TEXT NOT NULL,
-// label TEXT,
-// adminid INTEGER NOT NULL,
-// time DATE NOT NULL,
-//
-// FOREIGN KEY(adminid) REFERENCES users(id)
-// );
 const maxBatchAmount = 100
 const maxUnclaimedAmount = 500
 
@@ -715,9 +691,6 @@ func (d DB) DeleteInvitesBatch(batchid string) {
 	_, err = stmt.Exec(batchid)
 	util.Check(err, "execute delete")
 }
-
-/* TODO (2024-12-01): next up - start to write these database routines to parts that called from the server route
-* handlers :) */
 
 func (d DB) GetAllInvites() []InviteBatch {
 	ed := util.Describe("get all invites")

--- a/database/moderation.go
+++ b/database/moderation.go
@@ -61,6 +61,22 @@ func (d DB) RemoveUser(userid int) (finalErr error) {
 		return
 	}
 
+	/* TODO (2024-11-22): consider playing around with a "table-driven" refactor of the transaction here, as in example below:
+	* args - #1: descriptive error, #2 sql statement, #3 values to execute statement with
+	{
+		{"prepare posts stmt", `UPDATE posts SET content = "_deleted_", authorid = ? WHERE authorid = ?`, []int{deletedUserID, userid}}
+	}
+	then for _, row := range table {
+		row.preparedStmt = tx.Prepare(row[1]) .... rollBack  .... ed.Eout(err, row[0])
+	}
+
+	...
+
+	and then later for _, row := range table {
+		err = tx.Execute(row.preparedStmt, row[2]...)
+	}
+	*/
+
 	postsStmt, err := tx.Prepare(`UPDATE posts SET content = "_deleted_", authorid = ? WHERE authorid = ?`)
 	defer postsStmt.Close()
 	if rollbackOnErr(ed.Eout(err, "prepare posts stmt")) {

--- a/database/moderation.go
+++ b/database/moderation.go
@@ -709,7 +709,7 @@ func (d DB) GetAllInvites() []InviteBatch {
 	ed.Check(err, "create query")
 	
 	// keep track of invite batches by creating a key based on username + creation time
-	batches := make(map[string]InviteBatch)
+	batches := make(map[string]*InviteBatch)
 	var keys []string
 	var invite, username, label string
 	var t time.Time
@@ -724,7 +724,7 @@ func (d DB) GetAllInvites() []InviteBatch {
 			batch.UnclaimedInvites = append(batch.UnclaimedInvites, invite)
 		} else {
 			keys = append(keys, key)
-			batches[key] = InviteBatch{ActingUsername: username, UnclaimedInvites: []string{invite}, Label: label, Time: t}
+			batches[key] = &InviteBatch{ActingUsername: username, UnclaimedInvites: []string{invite}, Label: label, Time: t}
 		}
 	}
 
@@ -732,7 +732,7 @@ func (d DB) GetAllInvites() []InviteBatch {
 	ret := make([]InviteBatch, 0, len(keys))
 	sort.Strings(keys)
 	for _, key := range keys {
-		ret = append(ret, batches[key])
+		ret = append(ret, *batches[key])
 	}
 	return ret
 }

--- a/database/moderation.go
+++ b/database/moderation.go
@@ -742,7 +742,8 @@ func (d DB) GetAllInvites() []InviteBatch {
 
 	// convert from map to a []InviteBatch sorted by time using ts-prefixed map keys
 	ret := make([]InviteBatch, 0, len(keys))
-	sort.Strings(keys)
+	// we want newest first
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
 	for _, key := range keys {
 		ret = append(ret, *batches[key])
 	}

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -13,8 +13,8 @@ var DEFAULT_LOGO string
 //go:embed sample-rules.md
 var DEFAULT_RULES string
 
-//go:embed sample-verification-instructions.md
-var DEFAULT_VERIFICATION string
+//go:embed sample-registration-instructions.md
+var DEFAULT_REGISTRATION string
 
 //go:embed sample-config.toml
 var DEFAULT_CONFIG string

--- a/defaults/sample-config.toml
+++ b/defaults/sample-config.toml
@@ -12,4 +12,4 @@ forum_url = "" # should be forum index route https://example.com. used to genera
 logo =  "content/logo.html" # can contain emoji, <img>, <svg> etc. see defaults/sample-logo.html in repo for instructions
 about = "content/about.md"
 rules = "content/rules.md"
-verification_instructions = "content/verification-instructions.md"
+registration_instructions = "content/registration-instructions.md"

--- a/defaults/sample-registration-instructions.md
+++ b/defaults/sample-registration-instructions.md
@@ -1,0 +1,1 @@
+Request an invite code from one of the forum admins.

--- a/defaults/sample-verification-instructions.md
+++ b/defaults/sample-verification-instructions.md
@@ -1,4 +1,0 @@
-You can use either your mastodon profile or your webring site to verify your registration.
-
-* **Mastodon**: temporarily add a new metadata item to [your profile](https://merveilles.town/settings/profile) containing the verification code displayed above. Pass your profile as the verification link.
-* **Webring site**: Upload a plaintext file somewhere on your webring domain (incl. subdomain) containing the verification code from above. Pass the link to the uploaded file as the verification link (make sure it is viewable in a browser).

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 
 require (
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGw
 github.com/gomarkdown/markdown v0.0.0-20210514010506-3b9f47219fe7/go.mod h1:aii0r/K0ZnHv7G0KF7xy1v0A7s2Ljrb5byB7MO5p6TU=
 github.com/gomarkdown/markdown v0.0.0-20211212230626-5af6ad2f47df h1:M7mdNDTRraBcrHZg2aOYiFP9yTDajb6fquRZRpXnbVA=
 github.com/gomarkdown/markdown v0.0.0-20211212230626-5af6ad2f47df/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=

--- a/html/admin-invites.html
+++ b/html/admin-invites.html
@@ -4,18 +4,26 @@
     <p>Generate an invite and give to people for whom you want to enable account registration.</p>
     <p>You can <b>generate many invites at once</b>. If non-admin members are to be enabled to invite new users, then
     generate a batch of invite codes and post them in a private thread.</p>
-    <p>With <b>labeled invites</b>, you can separate different batches. Maybe one batch is for a friend group, 
+    <p>By <b>labeling invites</b>, you can separate different batches. Maybe one batch is for a friend group, 
     while another will be printed on slips of paper and given out at meetups.</p>
+    <p><b>Reusable invites</b> allows a single invite code to be used multiple times without expiring. To
+    stop the invite from being usable, <b>the invite must be deleted</b> below. Reusable invites provide a
+    smoother experience for onboarding preexisting community members by posting a reusable invite to a community
+    space compared to the continual management of invite code batches. However, reusable invites are a possible way for
+    unauthorized users to gain entry, such as spam accounts, so spread them carefully.</p>
 
-    <section>
+    <section id="create-invites">
 	<h2>Create invites</h2>
-        <p>Create a new batch of invite codes. The maximum amount of invites that can be created at once is 100, and 500
-        invites is the upper limit a single batch of invites can contain.</p>
+        <p>Create a new batch of invite codes. The maximum amount of invites that can be created at once is 100.</p>
 	<form method="POST" action="{{ .Data.CreateRoute }}">
 	    <label class="visually-hidden" for="amount">Amount of invites:</label>
 	    <input title="Amount of invites to create" type="number" value="1" min="1" max="100" id="amount" name="amount">
 	    <input maxlength="70" title="The invites you generate will be labeled using this text, and the label displayed below. It does not otherwise affect the invite." type="text" placeholder="e.g. server friends" id="label" name="label">
 	    <button type="submit">Create</button>
+            <div>
+            <input type="checkbox" id="multiuse-checkbox" name="reusable" value="true">
+            <label style="display: inline-block;" for="multiuse-checkbox">Make invite batch reusable (until deleted by an admin)</label>
+            </div>
 	</form>
     </section>
 
@@ -29,7 +37,7 @@
         {{ $deleteRoute := .Data.DeleteRoute }}
         {{ $forumRoot := .Data.ForumRootURL }}
         {{ range $index, $batch := .Data.Batches }}
-        <h3>{{ if len $batch.Label | eq 0 }} Unlabeled batch {{ else }} <i>"{{ $batch.Label }}"</i> {{ end }} created {{ $batch.Time | formatDate }} by {{ $batch.ActingUsername }}</h3>
+        <h3>{{ if $batch.Reusable }}[Reusable] {{ end }}{{ if len $batch.Label | eq 0 }} Unlabeled batch {{ else }} <i>"{{ $batch.Label }}"</i> {{ end }} created {{ $batch.Time | formatDate }} by {{ $batch.ActingUsername }}</h3>
             <form method="POST" action="{{ $deleteRoute }}" id="{{ $batch.BatchId }}">
                 <input type="hidden" name="batchid" value="{{ $batch.BatchId }}">
             </form>

--- a/html/admin-invites.html
+++ b/html/admin-invites.html
@@ -1,0 +1,60 @@
+{{ template "head" . }}
+<main>
+    <h1>Invites</h1>
+    <p>Generate an invite and give to people for whom you want to enable account registration.</p>
+    <p>You can <b>generate many invites at once</b>. If you want to enable invites
+from other non-admin members of the forum, generate a batch and dump them in a
+private thread.</p>
+    <p>With <b>labeled invites</b>, you can separate different batches. Maybe one batch is to
+be redeemed by a friend group, while another will be printed on slips of
+paper and given out at meetups.</p>
+
+    <section>
+	<h2>Create invites</h2>
+	<form method="POST" action="{{ .Data.CreateRoute }}">
+	    <!-- <label for="amount">Amount of invites:</label> -->
+	    <input title="Amount of invites to create" type="number" value="1" min="1" max="100" id="amount" name="amount">
+	    <input maxlength="70" title="The invites you generate will be labeled with this label, and displayed using it below. It does not otherwise affect the invite." type="text" placeholder="e.g. server friends" id="label" name="label">
+	    <button type="submit">Create</button>
+	</form>
+    </section>
+
+    <section>
+	<h2>Unclaimed invites</h2>
+        {{ if len .Data.Batches | eq 0}}
+        <p>There are currently no unclaimed invite batches that are issused.</p>
+        {{ end }}
+        {{ $deleteRoute := .Data.DeleteRoute }}
+        {{ range $index, $batch := .Data.Batches }}
+        <h3>{{ if len $batch.Label | eq 0 }} Unlabeled batch {{ else }} <i>"{{ $batch.Label }}"</i> {{ end }} created {{ $batch.Time | formatDate }} by {{ $batch.ActingUsername }}</h3>
+            <form method="POST" action="{{ $deleteRoute }}" id="{{ $batch.BatchId }}">
+                <input type="hidden" name="batchid" value="{{ $batch.BatchId }}">
+            </form>
+            <p>Delete remaining invites in this batch <button type="submit" form="{{$batch.BatchId}}">Delete</button></p>
+            <details>
+                <summary>Invites as code block</summary>
+                <pre style="user-select: all;">
+{{ range $index, $invite := $batch.UnclaimedInvites }}<code>{{ $invite }}</code>
+{{ end }}</pre>
+            </details>
+
+            <details>
+            <summary> Invites as pre-filled registration links</summary>
+            <ul>
+                {{ range $index, $invite := $batch.UnclaimedInvites }}
+                <li><a href="/">forum.com/register?invite={{ $invite }}</a></li>
+                {{ end }}
+            </ul>
+            </details>
+        {{ end }}
+
+    </section>
+
+    {{ if .Data.ErrorMessage }}
+    <div>
+        <p><b> {{ .Data.ErrorMessage }} </b></p>
+    </div>
+    {{ end }}
+
+</main>
+{{ template "footer" . }}

--- a/html/admin-invites.html
+++ b/html/admin-invites.html
@@ -41,6 +41,7 @@
             <form method="POST" action="{{ $deleteRoute }}" id="{{ $batch.BatchId }}">
                 <input type="hidden" name="batchid" value="{{ $batch.BatchId }}">
             </form>
+            <p style="margin: 0;">ID for this batch: <code>{{ $batch.BatchId }}</code></p>
             <p>Delete remaining invites in this batch <button type="submit" form="{{$batch.BatchId}}">Delete</button></p>
             <details>
                 <summary>Invites as code block</summary>

--- a/html/admin-invites.html
+++ b/html/admin-invites.html
@@ -2,19 +2,19 @@
 <main>
     <h1>Invites</h1>
     <p>Generate an invite and give to people for whom you want to enable account registration.</p>
-    <p>You can <b>generate many invites at once</b>. If you want to enable invites
-from other non-admin members of the forum, generate a batch and dump them in a
-private thread.</p>
-    <p>With <b>labeled invites</b>, you can separate different batches. Maybe one batch is to
-be redeemed by a friend group, while another will be printed on slips of
-paper and given out at meetups.</p>
+    <p>You can <b>generate many invites at once</b>. If non-admin members are to be enabled to invite new users, then
+    generate a batch of invite codes and post them in a private thread.</p>
+    <p>With <b>labeled invites</b>, you can separate different batches. Maybe one batch is for a friend group, 
+    while another will be printed on slips of paper and given out at meetups.</p>
 
     <section>
 	<h2>Create invites</h2>
+        <p>Create a new batch of invite codes. The maximum amount of invites that can be created at once is 100, and 500
+        invites is the upper limit a single batch of invites can contain.</p>
 	<form method="POST" action="{{ .Data.CreateRoute }}">
-	    <!-- <label for="amount">Amount of invites:</label> -->
+	    <label class="visually-hidden" for="amount">Amount of invites:</label>
 	    <input title="Amount of invites to create" type="number" value="1" min="1" max="100" id="amount" name="amount">
-	    <input maxlength="70" title="The invites you generate will be labeled with this label, and displayed using it below. It does not otherwise affect the invite." type="text" placeholder="e.g. server friends" id="label" name="label">
+	    <input maxlength="70" title="The invites you generate will be labeled using this text, and the label displayed below. It does not otherwise affect the invite." type="text" placeholder="e.g. server friends" id="label" name="label">
 	    <button type="submit">Create</button>
 	</form>
     </section>
@@ -23,8 +23,11 @@ paper and given out at meetups.</p>
 	<h2>Unclaimed invites</h2>
         {{ if len .Data.Batches | eq 0}}
         <p>There are currently no unclaimed invite batches that are issused.</p>
+        {{ else }} 
+        <p>Listed below are batches of invite codes that have yet to be claimed. If all invites from a batch have been used, the batch will no longer be displayed.</p>
         {{ end }}
         {{ $deleteRoute := .Data.DeleteRoute }}
+        {{ $forumRoot := .Data.ForumRootURL }}
         {{ range $index, $batch := .Data.Batches }}
         <h3>{{ if len $batch.Label | eq 0 }} Unlabeled batch {{ else }} <i>"{{ $batch.Label }}"</i> {{ end }} created {{ $batch.Time | formatDate }} by {{ $batch.ActingUsername }}</h3>
             <form method="POST" action="{{ $deleteRoute }}" id="{{ $batch.BatchId }}">
@@ -42,7 +45,7 @@ paper and given out at meetups.</p>
             <summary> Invites as pre-filled registration links</summary>
             <ul>
                 {{ range $index, $invite := $batch.UnclaimedInvites }}
-                <li><a href="/">forum.com/register?invite={{ $invite }}</a></li>
+                <li><a href="/register?invite={{ $invite }}">{{ if len $forumRoot | ne 0}}{{$forumRoot}}{{end}}/register?invite={{ $invite }}</a></li>
                 {{ end }}
             </ul>
             </details>

--- a/html/admin.html
+++ b/html/admin.html
@@ -72,7 +72,29 @@
         {{ end }}
     </table>
     {{ end }}
-
+    <section>
+        <h2>Registered invites</h2>
+        <p>Tallied invites based on the invite batch. Useful to see how invites are being claimed for different
+        batches.</p>
+        {{ if len .Data.Registrations| eq 0 }} 
+        <p><i>No invites have been redeemed yet.</i></p>
+        {{ else }}
+        <table>
+            <tr>
+                <th>Label</th>
+                <th>Uses</th>
+                <th>ID</th>
+            </tr>
+            {{ range $index, $reggedInvite := .Data.Registrations }}
+            <tr>
+                <td>{{ if len $reggedInvite.Label | eq 0 }} Unlabeled batch {{ else }} {{ $reggedInvite.Label }} {{ end }}</td>
+                <td style="text-align: center">{{ $reggedInvite.Count }}</td>
+                <td><details><summary style="margin: 0;">Batch ID</summary>{{ $reggedInvite.BatchID }}</details></td>
+            </tr>
+            {{ end }}
+        </table>
+        {{ end }}
+    </section>
     <section>
         <h2> {{ "AdminUsers" | translate }} </h2>
         {{ if len .Data.Users | eq 0 }} 
@@ -92,6 +114,7 @@
                             <option value="make-admin">{{ "AdminMakeAdmin" | translate }}</option>
                         </select>
                     </td>
+                    <td><details><summary style="margin: 0;">invite/register info</summary>{{ $user.RegistrationOrigin }}</details></td>
                     <td>
                         <button type="submit">{{ "Submit" | translate }}</button>
                     </td>

--- a/html/admin.html
+++ b/html/admin.html
@@ -3,10 +3,13 @@
     <h1>{{ .Title }}</h1>
     <section>
         <form method="GET" id="add-user" action="/add-user"></form>
-        <p>
+        <form method="GET" id="visit-invites" action="/invites"></form>
         <form method="POST" id="demote-self" action="/demote-admin">
             <input type="hidden" name="userid" value="{{ .LoggedInID }}">
         </form>
+        <p>
+        Do you want to view or create invites? <button form="visit-invites" type="submit">View invites</button>.
+        </p>
         <p>
         {{ "AdminAddNewUserQuestion" | translate }} <button form="add-user" type="submit"> {{ "AdminAddNewUser" | translate }}</button>.
         </p>

--- a/html/head.html
+++ b/html/head.html
@@ -154,7 +154,7 @@
                 display: none;
             }
 
-            header details {
+            summary {
                 cursor: pointer;
             }
             header details, header details summary {

--- a/html/register.html
+++ b/html/register.html
@@ -2,11 +2,10 @@
 <main>
     <h1> {{ "Register" | translate | capitalize }}</h1>
     {{ .Data.Rules }} <!-- registrationregistration  rules will be inserted here from the rules document being read from the config -->
-    <p>{{ "RegisterVerificationCode" | translate }} <b>{{ .Data.VerificationCode }}</b></p>
     <details>
-        <summary> {{ "RegisterVerificationInstructionsTitle" | translate }}</summary>
-        <!-- add your communities verification instructions by editing the verification-instructions document, see the config for where to find it!-->
-        {{ .Data.VerificationInstructions }}
+        <summary> {{ "RegisterInviteInstructionsTitle" | translate }}</summary>
+        <!-- add your communities registration instructions by editing the registration-instructions document, see the config for where to find it!-->
+        {{ .Data.InviteInstructions }}
     </details>
 
     <form method="post">
@@ -15,9 +14,8 @@
         <label for="password">{{ "Password" | translate | capitalize }}:</label>
         <input type="password" minlength="9" required id="password" name="password" aria-describedby="password-help" style="margin-bottom:0;">
         <div style="margin-bottom:1rem;"><small id="password-help">{{ "PasswordMin" | translate }}.</small></div>
-        <label for="verificationlink">{{ "RegisterVerificationLink" | translate }}: </label>
-        <input type="text" required id="verification link" name="verificationlink">
-        <input type="hidden" name="verificationcode" value="{{.Data.VerificationCode}}">
+        <label for="invite">Invite code: </label>
+        <input type="text" required id="invite" value="{{ .Data.InviteCode }}" name="invite">
         {{ if ne .Data.ConductLink "" }}
         <div>
             <div>

--- a/html/register.html
+++ b/html/register.html
@@ -1,10 +1,10 @@
 {{ template "head" . }}
 <main>
     <h1> {{ "Register" | translate | capitalize }}</h1>
-    {{ .Data.Rules }} <!-- registrationregistration  rules will be inserted here from the rules document being read from the config -->
+    {{ .Data.Rules }} <!-- registration rules will be inserted here from the rules document being read from the config -->
     <details>
         <summary> {{ "RegisterInviteInstructionsTitle" | translate }}</summary>
-        <!-- add your communities registration instructions by editing the registration-instructions document, see the config for where to find it!-->
+        <!-- add your community's registration instructions by editing the registration-instructions document, see the config for where to find it!-->
         {{ .Data.InviteInstructions }}
     </details>
 

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -27,6 +27,8 @@ var English = map[string]string{
 	"SortRecentPosts":   "recent posts",
 	"SortRecentThreads": "most recent threads",
 
+	"modlogCreateInvites":      `<code>{{ .Data.Time }}</code> <b>{{ .Data.ActingUsername }}</b> created a batch of invites`,
+	"modlogDeleteInvites":      `<code>{{ .Data.Time }}</code> <b>{{ .Data.ActingUsername }}</b> deleted a batch of invites`,
 	"modlogResetPassword":      `<code>{{ .Data.Time }}</code> <b>{{ .Data.ActingUsername }}</b> reset a user's password`,
 	"modlogResetPasswordAdmin": `<code>{{ .Data.Time }}</code> <b>{{ .Data.ActingUsername }}</b> reset <b> {{ .Data.RecipientUsername}}</b>'s password`,
 	"modlogRemoveUser":         `<code>{{ .Data.Time }}</code> <b>{{ .Data.ActingUsername }}</b> removed a user's account`,

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -151,9 +151,7 @@ var English = map[string]string{
 
 	"RegisterHTMLMessage": `You now have an account! Welcome. Visit the <a href="/">index</a> to read and reply to threads, or start a new one.`,
 
-	"RegisterVerificationCode":              "Your verification code is",
-	"RegisterVerificationInstructionsTitle": "Verification instructions",
-	"RegisterVerificationLink":              "Verification link",
+	"RegisterInviteInstructionsTitle": "How to get an invite code",
 	"RegisterConductCodeBoxOne":             `I have refreshed my memory of the <a target="_blank" href="{{ .Data.Link }}">{{ .Data.Name }} Code of Conduct</a>`,
 	"RegisterConductCodeBoxTwo":             `Yes, I have actually <a target="_blank" href="{{ .Data.Link }}">read it</a>`,
 
@@ -240,9 +238,7 @@ var Swedish = map[string]string{
 
 	"RegisterHTMLMessage": `Du har nu ett konto! Välkommen. Besök <a href="/">trådindexet</a> för att läsa och svara på trådar, eller för att starta en ny.`,
 
-	"RegisterVerificationCode":              "Din verifikationskod är",
-	"RegisterVerificationInstructionsTitle": "Verification instructions",
-	"RegisterVerificationLink":              "Verificationsnyckel",
+	"RegisterInviteInstructionsTitle": "Instruktioner för invitationskod",
 	"RegisterConductCodeBoxOne":             `I have refreshed my memory of the <a target="_blank" href="{{ .Data.Link }}">{{ .Data.Name }} Code of Conduct</a>`,
 	"RegisterConductCodeBoxTwo":             `Yes, I have actually <a target="_blank" href="{{ .Data.Link }}">read it</a>`,
 
@@ -331,9 +327,7 @@ var EspanolMexicano = map[string]string{
 
 	"RegisterHTMLMessage": `You now have an account! Welcome. Visit the <a href="/">index</a> to read and reply to threads, or start a new one.`,
 
-	"RegisterVerificationCode":              "Your verification code is",
-	"RegisterVerificationInstructionsTitle": "Verification instructions",
-	"RegisterVerificationLink":              "Verification link",
+	"RegisterInviteInstructionsTitle":			 "How to get an invite code",
 	"RegisterConductCodeBoxOne":             `I have refreshed my memory of the <a target="_blank" href="{{ .Data.Link }}">{{ .Data.Name }} Code of Conduct</a>`,
 	"RegisterConductCodeBoxTwo":             `Yes, I have actually <a target="_blank" href="{{ .Data.Link }}">read it</a>`,
 

--- a/server/moderation.go
+++ b/server/moderation.go
@@ -512,7 +512,8 @@ func (h *RequestHandler) AdminInvitesCreateBatch(res http.ResponseWriter, req *h
 	util.Check(err, "parse amount as int")
 	var label string
 	label = req.PostFormValue("label")
-	err = h.db.CreateInvites(adminUserId, amount, label)
+	reusable := (req.PostFormValue("reusable") == "true")
+	err = h.db.CreateInvites(adminUserId, amount, label, reusable)
 	if err != nil {
 		fmt.Printf("%v\n", ed.Eout(err, "create invites"))
 		return
@@ -523,7 +524,8 @@ func (h *RequestHandler) AdminInvitesCreateBatch(res http.ResponseWriter, req *h
 		fmt.Println(ed.Eout(modlogErr, "error adding moderation log"))
 	}
 
-	http.Redirect(res, req, INVITES_ROUTE, http.StatusFound)
+	// refresh and show the create invite section
+	http.Redirect(res, req, fmt.Sprintf("%s%s", INVITES_ROUTE, "#create-invites"), http.StatusFound)
 }
 
 func (h *RequestHandler) AdminInvitesDeleteBatch(res http.ResponseWriter, req *http.Request) {
@@ -540,7 +542,8 @@ func (h *RequestHandler) AdminInvitesDeleteBatch(res http.ResponseWriter, req *h
 	if modlogErr != nil {
 		fmt.Println(ed.Eout(modlogErr, "error adding moderation log"))
 	}
-	http.Redirect(res, req, INVITES_ROUTE, http.StatusFound)
+	// refresh and show the create invite section
+	http.Redirect(res, req, fmt.Sprintf("%s%s", INVITES_ROUTE, "#create-invites"), http.StatusFound)
 }
 
 // view of /admin for non-admin users (contains less information)

--- a/server/moderation.go
+++ b/server/moderation.go
@@ -257,6 +257,61 @@ func (h *RequestHandler) AdminManualAddUserRoute(res http.ResponseWriter, req *h
 	}
 }
 
+func (h *RequestHandler) AdminInvitesRoute(res http.ResponseWriter, req *http.Request) {
+	// ed := util.Describe("admin invites route")
+	loggedIn, _ := h.IsLoggedIn(req)
+	isAdmin, adminUserId := h.IsAdmin(req)
+	fmt.Println(adminUserId)
+
+	if !isAdmin {
+		IndexRedirect(res, req)
+		return
+	}
+
+	type Invites struct {
+		ErrorMessage string
+	}
+
+	var data Invites
+	view := TemplateData{Title: "Invites", Data: &data, HasRSS: false, IsAdmin: isAdmin, LoggedIn: loggedIn}
+
+	if req.Method == "GET" {
+		h.renderView(res, "admin-invites", view)
+		return
+	}
+
+// 	if req.Method == "POST" && isAdmin {
+// 		username := req.PostFormValue("username")
+//
+// 		// do a lil quick checky check to see if we already have that username registered,
+// 		// and if we do re-render the page with an error
+// 		existed, err := h.db.CheckUsernameExists(username)
+// 		ed.Check(err, "check username exists")
+//
+// 		if existed {
+// 			data.ErrorMessage = fmt.Sprintf("Username (%s) is already registered", username)
+// 			h.renderView(res, "admin-add-user", view)
+// 			return
+// 		}
+//
+// 		// set up basic credentials
+// 		newPassword := crypto.GeneratePassword()
+// 		passwordHash, err := crypto.HashPassword(newPassword)
+// 		ed.Check(err, "hash password")
+// 		targetUserId, err := h.db.CreateUser(username, passwordHash)
+// 		ed.Check(err, "create new user %s", username)
+//
+// 		err = h.db.AddModerationLog(adminUserId, targetUserId, constants.MODLOG_ADMIN_ADD_USER)
+// 		if err != nil {
+// 			fmt.Println(ed.Eout(err, "error adding moderation log"))
+// 		}
+//
+// 		title := h.translator.Translate("AdminAddNewUser")
+// 		message := fmt.Sprintf(h.translator.Translate("AdminPasswordSuccessInstructions"), template.HTMLEscapeString(username), newPassword)
+// 		h.displaySuccess(res, req, title, message, "/add-user")
+// 	}
+}
+
 func (h *RequestHandler) AdminResetUserPassword(res http.ResponseWriter, req *http.Request, targetUserId int) {
 	ed := util.Describe("admin reset password")
 	loggedIn, _ := h.IsLoggedIn(req)

--- a/server/server.go
+++ b/server/server.go
@@ -241,6 +241,7 @@ func generateTemplates(config types.Config, translator i18n.Translator) (*templa
 		"admin",
 		"admins-list",
 		"admin-add-user",
+		"admin-invites",
 		"moderation-log",
 		"password-reset",
 		"change-password",
@@ -1023,6 +1024,7 @@ func NewServer(allowlist []string, sessionKey, dir string, config types.Config) 
 	s.ServeMux.HandleFunc("/admin", handler.AdminRoute)
 	s.ServeMux.HandleFunc("/demote-admin", handler.AdminDemoteAdmin)
 	s.ServeMux.HandleFunc("/add-user", handler.AdminManualAddUserRoute)
+	s.ServeMux.HandleFunc("/invites", handler.AdminInvitesRoute)
 	s.ServeMux.HandleFunc("/moderations", handler.ModerationLogRoute)
 	s.ServeMux.HandleFunc("/proposal-veto", handler.VetoProposal)
 	s.ServeMux.HandleFunc("/proposal-confirm", handler.ConfirmProposal)

--- a/server/server.go
+++ b/server/server.go
@@ -675,11 +675,8 @@ func (h RequestHandler) RegisterRoute(res http.ResponseWriter, req *http.Request
 	case "POST":
 		username := req.PostFormValue("username")
 		password := req.PostFormValue("password")
-		// // skip invite code during dev registering
-		// if !developing {
-			// read submitted invite code from form
-			inviteCode = req.PostFormValue("invite")
-		// }
+		// read submitted invite code from form
+		inviteCode = req.PostFormValue("invite")
 
 		// make sure username is not registered already
 		var exists bool

--- a/server/server.go
+++ b/server/server.go
@@ -977,6 +977,10 @@ func (u *CercaForum) directory() string {
 	return u.Directory
 }
 
+const INVITES_ROUTE = "/invites"
+const INVITES_CREATE_ROUTE = "/invites/create"
+const INVITES_DELETE_ROUTE = "/invites/delete"
+
 // NewServer sets up a new CercaForum object. Always use this to initialize
 // new CercaForum objects. Pass the result to http.Serve() with your choice
 // of net.Listener.
@@ -1024,7 +1028,9 @@ func NewServer(allowlist []string, sessionKey, dir string, config types.Config) 
 	s.ServeMux.HandleFunc("/admin", handler.AdminRoute)
 	s.ServeMux.HandleFunc("/demote-admin", handler.AdminDemoteAdmin)
 	s.ServeMux.HandleFunc("/add-user", handler.AdminManualAddUserRoute)
-	s.ServeMux.HandleFunc("/invites", handler.AdminInvitesRoute)
+	s.ServeMux.HandleFunc(INVITES_ROUTE, handler.AdminInvitesRoute)
+	s.ServeMux.HandleFunc(INVITES_CREATE_ROUTE, handler.AdminInvitesCreateBatch)
+	s.ServeMux.HandleFunc(INVITES_DELETE_ROUTE, handler.AdminInvitesDeleteBatch)
 	s.ServeMux.HandleFunc("/moderations", handler.ModerationLogRoute)
 	s.ServeMux.HandleFunc("/proposal-veto", handler.VetoProposal)
 	s.ServeMux.HandleFunc("/proposal-confirm", handler.ConfirmProposal)

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -39,7 +39,6 @@ const cookieName = "cerca"
 
 const INDEX_SETTINGS = "IndexSettings"
 const USER_ID = "userid"
-const VERIFICATION_CODE = "verificationCode"
 
 type Session struct {
 	Store           *sessions.CookieStore
@@ -97,14 +96,6 @@ func getValueFromSession(req *http.Request, store *sessions.CookieStore, key str
 	return value, nil
 }
 
-func (s *Session) GetVerificationCode(req *http.Request) (string, error) {
-	val, err := getValueFromSession(req, s.ShortLivedStore, VERIFICATION_CODE)
-	if val == nil || err != nil {
-		return "", err
-	}
-	return val.(string), err
-}
-
 func (s *Session) Get(req *http.Request) (int, error) {
 	val, err := getValueFromSession(req, s.Store, USER_ID)
 	if val == nil || err != nil {
@@ -135,10 +126,6 @@ func (s *Session) genericSave(req *http.Request, res http.ResponseWriter, shortL
 
 func (s *Session) Save(req *http.Request, res http.ResponseWriter, userid int) error {
 	return s.genericSave(req, res, false, USER_ID, userid)
-}
-
-func (s *Session) SaveVerificationCode(req *http.Request, res http.ResponseWriter, code string) error {
-	return s.genericSave(req, res, true, VERIFICATION_CODE, code)
 }
 
 func (s *Session) SaveIndexSettings(req *http.Request, res http.ResponseWriter, params string) error {

--- a/types/types.go
+++ b/types/types.go
@@ -21,7 +21,7 @@ type Config struct {
 		LogoPath                    string `json:"logo"`
 		AboutPath                   string `json:"about"`
 		RegisterRulesPath           string `json:"rules"`
-		VerificationExplanationPath string `json:"verification_instructions"`
+		RegistrationExplanationPath string `json:"registration_instructions"`
 	} `json:"documents"`
 }
 
@@ -33,8 +33,8 @@ func (c *Config) EnsureDefaultPaths() {
 	if c.Documents.RegisterRulesPath == "" {
 		c.Documents.RegisterRulesPath = filepath.Join("content", "rules.md")
 	}
-	if c.Documents.VerificationExplanationPath == "" {
-		c.Documents.VerificationExplanationPath = filepath.Join("content", "verification-instructions.md")
+	if c.Documents.RegistrationExplanationPath == "" {
+		c.Documents.RegistrationExplanationPath = filepath.Join("content", "registration-instructions.md")
 	}
 	if c.Documents.LogoPath == "" {
 		c.Documents.LogoPath = filepath.Join("content", "logo.html")
@@ -53,5 +53,5 @@ language = "English"
 logo = "./logo.svg"
 about = "./about.md"
 rules = "./rules.md"
-verification_instructions = "./verification-instructions.md"
+registration_instructions = "./registration-instructions.md"
 */

--- a/util/util.go
+++ b/util/util.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/parser"
 	"github.com/gomarkdown/markdown/ast"
@@ -270,4 +271,10 @@ func LoadFile(key, docpath, defaultContent string) ([]byte, error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+func GetUUIDv4 () string {
+	identifier, err := uuid.NewRandom()
+	Check(err, "generated invites using uuid v4")
+	return identifier.String()
 }

--- a/util/util.go
+++ b/util/util.go
@@ -136,16 +136,6 @@ func SanitizeStringStrict(s string) string {
 	return strictContentGuardian.Sanitize(s)
 }
 
-func VerificationPrefix(name string) string {
-	pattern := regexp.MustCompile("A|E|O|U|I|Y")
-	upper := strings.ToUpper(name)
-	replaced := string(pattern.ReplaceAll([]byte(upper), []byte("")))
-	if len(replaced) < 3 {
-		replaced += "XYZ"
-	}
-	return replaced[0:3]
-}
-
 func GetThreadSlug(threadid int, title string, threadLen int) string {
 	return fmt.Sprintf("/thread/%d/%s-%d/", threadid, SanitizeURL(title), threadLen)
 }


### PR DESCRIPTION
This feature adds invite functionality to the forum. An invite allows a person without an account to redeem the invite during account registration, granting entry to the forum as a member.

![cerca-invites-wip](https://github.com/user-attachments/assets/7d7dd914-18f7-4d81-af9a-121e8766f8a5)

Invites are created by admins and they are UUID v4 identifiers. Invites have yet to be claimed are displayed as either a plain UUID v4 string or formatted as a link to the forum's `/register` route, with the invite as a URL parameter.

If a forum community wants to let its users freely invite their friends, admins can, for example, generate a large batch of invites and post them in a private thread.

Invites can optionally be labeled, to allow for creating different batches for different purposes and keep the batches separate so that they are not "redeemed too quickly".
 
closes  #75