### PR TITLE
Single binary tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ It was written for the purpose of powering the nascent [Merveilles community for
 ## Usage
 
 ```
+cerca --help
+
 USAGE:
-    cerca -allowlist allow.txt -authkey "CHANGEME"
-    cerca -dev
+  run the forum
+
+  cerca -allowlist allow.txt -authkey "CHANGEME"
+  cerca -dev
 
 COMMANDS:
-    admin     promote user to admin
-    migrate   manage database migrations
-    user      create new user
-    reset     reset user password
-
-GLOBAL OPTIONS:
-    -help
-        show help
+  adduser    create a new user
+  makeadmin  make an existing user an admin
+  migrate    manage database migrations
+  resetpw    reset a user's password
 
 OPTIONS:
   -allowlist string
@@ -52,6 +52,12 @@ OPTIONS:
         directory where cerca will dump its database (default "./data")
   -dev
         trigger development mode
+```
+
+To execute the other commands, run them as:
+
+```
+cerca adduser --username "<username>"
 ```
 
 ## Config
@@ -115,19 +121,24 @@ Install [golang](https://go.dev/).
 
 To launch a local instance of the forum, run those commands (linux):
 
-- `go run run.go --dev`
+- `go run ./cmd/cerca --dev`
 
 It should respond `Serving forum on :8277`. Just go on [http://localhost:8277](http://localhost:8277).
 
-### Building binaries with reduced size 
-This is optional, but if you want to minimize the size of any binary (whether it be the `cerca` executable 
-or any of the binaries in [`cmd/`](/cmd/) follow the instructions below. Less useful for active development, more 
-useful for sending binaries to other computers.
+### Building a binary
+
+```
+go build ./cmd/cerca
+```
+
+### Building with reduced size 
+This is optional, but if you want to minimize the size of the binary follow the instructions
+below. Less useful for active development, more useful for sending binaries to other computers.
 
 Pass `-ldflags="-s -w"` when building your binary:
 
 ```
-go build -ldflags="-s -w" .
+go build -ldflags="-s -w" ./cmd/cerca
 ```
 
 Additionally, run [upx](https://upx.github.io) on any generated binary:

--- a/cmd/cerca/admin.go
+++ b/cmd/cerca/admin.go
@@ -13,16 +13,22 @@ func admin() {
 	var forumDomain string
 	var dbPath string
 
-	adminCmd := flag.NewFlagSet("admin", flag.ExitOnError)
-	adminCmd.StringVar(&forumDomain, "url", "https://forum.merveilles.town", "root url to forum, referenced in output")
-	adminCmd.StringVar(&username, "username", "", "username who should be made admin")
-	adminCmd.StringVar(&dbPath, "database", "./data/forum.db", "full path to the forum database; e.g. ./data/forum.db")
+	adminFlags := flag.NewFlagSet("makeadmin", flag.ExitOnError)
+	adminFlags.StringVar(&forumDomain, "url", "https://forum.merveilles.town", "root url to forum, referenced in output")
+	adminFlags.StringVar(&username, "username", "", "username who should be made admin")
+	adminFlags.StringVar(&dbPath, "database", "./data/forum.db", "full path to the forum database; e.g. ./data/forum.db")
 
-	help := createHelpString([]string{
-		"cerca admin -username myCoolUsername",
-	}, false)
-	adminCmd.Usage = func() { usage(help, adminCmd) }
-	adminCmd.Parse(os.Args[2:])
+	help := createHelpString("makeadmin", []string{
+		`cerca makeadmin -username "<existing username>"`,
+	})
+	adminFlags.Usage = func() { usage(help, adminFlags) }
+	adminFlags.Parse(os.Args[2:])
+
+	// if run without flags, print the help info
+	if adminFlags.NFlag() == 0 {
+		adminFlags.Usage()
+		return
+	}
 
 	adminRoute := fmt.Sprintf("%s/admin", forumDomain)
 

--- a/cmd/cerca/migrate.go
+++ b/cmd/cerca/migrate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 )
 
+
 func migrate() {
 	migrations := map[string]func(string) error{
 		"2024-01-password-hash-migration":  database.Migration20240116_PwhashChange,
@@ -16,17 +17,23 @@ func migrate() {
 	var dbPath, migration string
 	var listMigrations bool
 
-	migrateCmd := flag.NewFlagSet("migrate", flag.ExitOnError)
-	migrateCmd.BoolVar(&listMigrations, "list", false, "list possible migrations")
-	migrateCmd.StringVar(&migration, "migration", "", "name of the migration you want to perform on the database")
-	migrateCmd.StringVar(&dbPath, "database", "./data/forum.db", "full path to the forum database; e.g. ./data/forum.db")
+	migrateFlags := flag.NewFlagSet("migrate", flag.ExitOnError)
+	migrateFlags.BoolVar(&listMigrations, "list", false, "list possible migrations")
+	migrateFlags.StringVar(&migration, "migration", "", "name of the migration you want to perform on the database")
+	migrateFlags.StringVar(&dbPath, "database", "./data/forum.db", "full path to the forum database; e.g. ./data/forum.db")
 
-	help := createHelpString([]string{
-		"cerca -migration \"2024-02-thread-private-migration\"",
+	help := createHelpString("migrate", []string{
+		`cerca migrate -migration 2024-02-thread-private-migration`,
 		"cerca migrate -list",
-	}, false)
-	migrateCmd.Usage = func() { usage(help, migrateCmd) }
-	migrateCmd.Parse(os.Args[2:])
+	})
+	migrateFlags.Usage = func() { usage(help, migrateFlags) }
+	migrateFlags.Parse(os.Args[2:])
+
+	// if run without flags, print the help info
+	if migrateFlags.NFlag() == 0 {
+		migrateFlags.Usage()
+		return
+	}
 
 	if listMigrations {
 		inform("Possible migrations:")

--- a/cmd/cerca/reset.go
+++ b/cmd/cerca/reset.go
@@ -11,15 +11,21 @@ func reset() {
 	var username string
 	var dbPath string
 
-	resetCmd := flag.NewFlagSet("reset", flag.ExitOnError)
-	resetCmd.StringVar(&username, "username", "", "username whose credentials should be reset")
-	resetCmd.StringVar(&dbPath, "database", "./data/forum.db", "full path to the forum database; e.g. ./data/forum.db")
+	resetFlags := flag.NewFlagSet("resetpw", flag.ExitOnError)
+	resetFlags.StringVar(&username, "username", "", "username whose credentials should be reset")
+	resetFlags.StringVar(&dbPath, "database", "./data/forum.db", "full path to the forum database; e.g. ./data/forum.db")
 
-	help := createHelpString([]string{
-		"cerca reset -username myCoolUsername",
-	}, false)
-	resetCmd.Usage = func() { usage(help, resetCmd) }
-	resetCmd.Parse(os.Args[2:])
+	help := createHelpString("resetpw", []string{
+		`cerca resetpw -username "<existing username>"`,
+	})
+	resetFlags.Usage = func() { usage(help, resetFlags) }
+	resetFlags.Parse(os.Args[2:])
+
+	// if run without flags, print the help info
+	if resetFlags.NFlag() == 0 {
+		resetFlags.Usage()
+		return
+	}
 
 	if username == "" {
 		complain(help)

--- a/cmd/cerca/user.go
+++ b/cmd/cerca/user.go
@@ -45,16 +45,22 @@ func user() {
 	var forumDomain string
 	var dbPath string
 
-	userCmd := flag.NewFlagSet("user", flag.ExitOnError)
-	userCmd.StringVar(&forumDomain, "url", "https://forum.merveilles.town", "root url to forum, referenced in output")
-	userCmd.StringVar(&username, "username", "", "username who should be created")
-	userCmd.StringVar(&dbPath, "database", "./data/forum.db", "full path to the forum database; e.g. ./data/forum.db")
+	userFlags := flag.NewFlagSet("adduser", flag.ExitOnError)
+	userFlags.StringVar(&forumDomain, "url", "https://forum.merveilles.town", "root url to forum, referenced in output")
+	userFlags.StringVar(&username, "username", "", "username who should be created")
+	userFlags.StringVar(&dbPath, "database", "./data/forum.db", "full path to the forum database; e.g. ./data/forum.db")
 
-	help := createHelpString([]string{
-		"cerca user -username myCoolUsername",
-	}, false)
-	userCmd.Usage = func() { usage(help, userCmd) }
-	userCmd.Parse(os.Args[2:])
+	help := createHelpString("adduser", []string{
+		`cerca adduser -username "<new username>"`,
+	})
+	userFlags.Usage = func() { usage(help, userFlags) }
+	userFlags.Parse(os.Args[2:])
+
+	// if run without flags, print the help info
+	if userFlags.NFlag() == 0 {
+		userFlags.Usage()
+		return
+	}
 
 	if username == "" {
 		complain(help)


### PR DESCRIPTION
  last mile tweaks for single binary refactor
  
  changes:
  
  * updated readme to reflect new procedure for running cerca dev commands
  * changed command names to better reflect their purpose
  * fixed inconsistency depending on number of flags provided
  * output a brief context explanation for each command during --help
  * fixed typo in migrate command usage
  * rename ./cmd/cerca/cerca.go -> ./cmd/cerca/main.go

cc @decentral1se any thoughts or should i just marge it in