### PR TITLE
README: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cerca
-_a forum software_
+_lean forum software_
 
 Meaning:
 * to search, quest, run _(it)_


### PR DESCRIPTION
I think this is better, since [“software” is uncountable](https://en.wiktionary.org/wiki/software#Noun).