### PR TITLE
allow /thread/new to have title populated via url param

### DIFF
--- a/html/new-thread.html
+++ b/html/new-thread.html
@@ -4,7 +4,7 @@
     <form method="POST">
         <div class="post-container" >
             <label for="title">{{ "Title" | translate }}:</label>
-            <input autofocus required name="title" type="text" id="title">
+            <input autofocus required name="title" type="text" value="{{ .Data.NewTitle }}" id="title">
             <label for="content">{{ "Content" | translate }}:</label>
             <textarea required name="content" id="content" placeholder='{{ "TextareaPlaceholder" | translate }}'></textarea>
             <div id="thread-private">

--- a/server/server.go
+++ b/server/server.go
@@ -768,8 +768,15 @@ func (h *RequestHandler) NewThreadRoute(res http.ResponseWriter, req *http.Reque
 			h.renderGenericMessage(res, req, data)
 			return
 		}
+
+		params := req.URL.Query()
+		var newTitle string
+		if _, exists := params["title"]; exists {
+			newTitle = params["title"][0]
+		}
+		// note: for Data we pass and initialize an anonymous struct that only contains NewTitle. this makes newTitle accessible in html/new-thread.html as .Data.NewTitle
 		h.renderView(res, "new-thread", TemplateData{
-			HasRSS: h.config.RSS.URL != "", LoggedIn: loggedIn, Title: h.translator.Translate("ThreadNew")})
+			Data: struct{NewTitle string}{newTitle}, HasRSS: h.config.RSS.URL != "", LoggedIn: loggedIn, Title: h.translator.Translate("ThreadNew")})
 	case "POST":
 		// Handle POST (=>
 		title := req.PostFormValue("title")


### PR DESCRIPTION
GET <forum-domain>/thread/new?title="your title here", where `?title="your title here"` can now be used to pre-populate the thread title. as when creating a new thread, this is only relevant if a user is logged in as non-authorized users will see a generic "you gotta log in" message

related to and closes #104