### PR TITLE
feat(cerca/cmd): add cerca genauthkey util

### DIFF
--- a/cmd/cerca/authkey.go
+++ b/cmd/cerca/authkey.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"cerca/crypto"
+	"crypto/sha256"
+	"flag"
+)
+
+
+func authkey() {
+	authkeyFlags := flag.NewFlagSet("adduser", flag.ExitOnError)
+
+	help := createHelpString("authkey", []string{
+		`cerca authkey <no other args>`,
+	})
+	authkeyFlags.Usage = func() { usage(help, authkeyFlags) }
+
+	hashInput := []byte(crypto.GeneratePassword())
+	h := sha256.New()
+	h.Write(hashInput)
+	inform("Generated a random key:")
+	inform("--authkey %x", h.Sum(nil))
+}

--- a/cmd/cerca/main.go
+++ b/cmd/cerca/main.go
@@ -16,6 +16,7 @@ var commandExplanations = map[string]string{
 	"makeadmin": "make an existing user an admin",
 	"migrate":   "manage database migrations",
 	"resetpw":   "reset a user's password",
+	"genauthkey": "generate and output an authkey for use with `cerca run`",
 }
 
 func createHelpString(commandName string, usageExamples []string) string {
@@ -25,7 +26,7 @@ func createHelpString(commandName string, usageExamples []string) string {
 
 	if commandName == "run" {
 		helpString += "\nCOMMANDS:\n"
-		cmds := []string{"adduser", "makeadmin", "migrate", "resetpw"}
+		cmds := []string{"adduser", "makeadmin", "migrate", "resetpw", "genauthkey"}
 		for _, key := range cmds {
 			// pad first string with spaces to the right instead, set its expected width = 11
 			helpString += fmt.Sprintf("  %-11s%s\n", key, commandExplanations[key])
@@ -117,6 +118,8 @@ func main() {
 		reset()
 	case "run":
 		run()
+	case "genauthkey":
+		authkey()
 	default:
 		fmt.Printf("ERR: no such subcommand '%s'\n", command)
 		run()


### PR DESCRIPTION
as part of attending to first setup friction (#101), this commit implements a util that can be invoked as:

    cerca genauthkey

which outputs:

    Generated a random key:
    --authkey 14b55e1615bff41ca0bb217a4916e1f7341df07740e7f802c5eb973c573b62b3

the output can be copied and used directly with cerca to serve a fresh instance, e.g:

    cerca --authkey 14b55e1615bff41ca0bb217a4916e1f7341df07740e7f802c5eb973c573b62b3