### PR TITLE
cmd: add cerca version command to output commit hash and build info

### DIFF
--- a/cmd/cerca/main.go
+++ b/cmd/cerca/main.go
@@ -19,6 +19,7 @@ var commandExplanations = map[string]string{
 	"migrate":    "manage database migrations",
 	"resetpw":    "reset a user's password",
 	"genauthkey": "generate and output an authkey for use with `cerca run`",
+	"version":    "output version information",
 }
 
 func createHelpString(commandName string, usageExamples []string) string {
@@ -28,7 +29,7 @@ func createHelpString(commandName string, usageExamples []string) string {
 
 	if commandName == "run" {
 		helpString += "\nCOMMANDS:\n"
-		cmds := []string{"adduser", "makeadmin", "migrate", "resetpw", "genauthkey"}
+		cmds := []string{"adduser", "makeadmin", "migrate", "resetpw", "genauthkey", "version"}
 		for _, key := range cmds {
 			// pad first string with spaces to the right instead, set its expected width = 11
 			helpString += fmt.Sprintf("  %-11s%s\n", key, commandExplanations[key])
@@ -135,6 +136,8 @@ func main() {
 		run()
 	case "genauthkey":
 		authkey()
+	case "version":
+		version()
 	default:
 		fmt.Printf("ERR: no such subcommand '%s'\n", command)
 		run()

--- a/cmd/cerca/version.go
+++ b/cmd/cerca/version.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"time"
+	"runtime/debug"
+	"fmt"
+)
+
+type CommitInfo struct {
+	Date string
+	Hash string
+}
+
+func (c CommitInfo) String() string {
+	return fmt.Sprintf("latest commit %s - %s", c.Date, c.Hash)
+}
+
+func version() {
+	now := time.Now()
+	// we can only get the git commit info when built by invoking `go build` (as opposed to being built & immediately
+	// executed via `go run`)
+	isBuiltBinary := false
+	var commit CommitInfo 
+	var golangVersion string
+	date := now.UTC().Format(time.UnixDate)
+	if info, ok := debug.ReadBuildInfo(); ok {
+		golangVersion = info.GoVersion
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs" {
+				isBuiltBinary = true
+			}
+			if setting.Key == "vcs.revision" {
+				commit.Hash = setting.Value
+			}
+			if setting.Key == "vcs.time" {
+				t, err := time.Parse(time.RFC3339, setting.Value)
+				if err == nil {
+					commit.Date = t.Format(time.DateOnly)
+				}
+			}
+		}
+	}
+	inform("built on %s with %s", date, golangVersion)
+	if isBuiltBinary {
+		inform(commit.String())
+	} else {
+		inform("running with go run, git hash not available")
+	}
+
+}


### PR DESCRIPTION
for example:

    go build ./cmd/cerca
    ./cerca version

    built on Wed May 21 19:12:43 UTC 2025 with go1.24.0
    latest commit 2025-05-10 - a2706a35e3efc8b816b4374e24493548429041db

closes #113 