### PR TITLE
add CERCA_ROOT and Config.Tooling.CercaRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The configuration format is [TOML](https://toml.io/en/) and the config is popula
 defaults:
 
 ```TOML
+[tooling]
+cerca_root = "" # optional - see docs/hosting.md for more info. if set, this should point to the folder hosting the base of your forum. 
+                # can also be set with the CERCA_ROOT environment variable
+
 [general]	
 name = "" # whatever you want to name your forum; primarily used as display in tab titles
 conduct_url = "" # optional + recommended: if omitted, the CoC checkboxes in /register will be hidden

--- a/cmd/cerca/main.go
+++ b/cmd/cerca/main.go
@@ -106,13 +106,7 @@ func run() {
 		sessionKey = "0"
 	}
 
-	var cercaRoot string
-	for _, env := range os.Environ() {
-		parts := strings.Split(env, "=")
-		if parts[0] == "CERCA_ROOT" {
-			cercaRoot = parts[1]
-		}
-	}
+	cercaRoot := util.GetEnvCercaRoot()
 
 	// if --config isn't set and CERCA_ROOT is set, set config path to use the cerca root/cerca.toml
 	if configPath == DEFAULT_CONFIG_NAME && cercaRoot != "" {
@@ -120,7 +114,7 @@ func run() {
 	}
 
 	config := util.ReadConfig(configPath)
-	// if CERCA_ROOT env var is set but config.Tooling.CercaRoot is not set, then use the CERCA_ROOT  value.
+	// if CERCA_ROOT env var is set but config.Tooling.CercaRoot is not set, then use the CERCA_ROOT value.
 	// note that implicitly, config.Tooling.CercaRoot takes precedence over any env variable CERCA_ROOT if both are set
 	if cercaRoot != "" && config.Tooling.CercaRoot == "" {
 		config.Tooling.CercaRoot = cercaRoot
@@ -136,8 +130,6 @@ func run() {
 		complain(fmt.Sprintf("couldn't create dir '%s'", dataDir))
 	}
 
-
-	//                             vvvvvvvvvdoes this make sense wrt rest of system?vv
 	_, err = util.CreateIfNotExist(config.JoinWithRoot("html", "assets", "theme.css"), defaults.DEFAULT_THEME)
 	if err != nil {
 		complain("couldn't output default theme.css")

--- a/cmd/cerca/main.go
+++ b/cmd/cerca/main.go
@@ -108,7 +108,7 @@ func run() {
 
 	cercaRoot := util.GetEnvCercaRoot()
 
-	// if --config isn't set and CERCA_ROOT is set, set config path to use the cerca root/cerca.toml
+	// if --config isn't set and CERCA_ROOT is set, set config lookup path to "$CERCA_ROOT/cerca.toml"
 	if configPath == DEFAULT_CONFIG_NAME && cercaRoot != "" {
 		configPath = util.JoinWithBase(cercaRoot, DEFAULT_CONFIG_NAME)
 	}
@@ -116,9 +116,7 @@ func run() {
 	config := util.ReadConfig(configPath)
 	// if CERCA_ROOT env var is set but config.Tooling.CercaRoot is not set, then use the CERCA_ROOT value.
 	// note that implicitly, config.Tooling.CercaRoot takes precedence over any env variable CERCA_ROOT if both are set
-	if cercaRoot != "" && config.Tooling.CercaRoot == "" {
-		config.Tooling.CercaRoot = cercaRoot
-	}
+	util.EnsureCercaRootSet(&config)
 
 	// if --data is not passed, then join the default dataDir with the cerca root
 	if dataDir == DEFAULT_DATA_DIR && config.Tooling.CercaRoot != "" {

--- a/defaults/sample-config.toml
+++ b/defaults/sample-config.toml
@@ -1,3 +1,7 @@
+[tooling]
+cerca_root = "" # optional - see docs/hosting.md for more info. if set, this should point to the folder hosting the base of your forum. 
+                # can also be set with the CERCA_ROOT environment variable
+
 [general]	
 name = "" # whatever you want to name your forum; primarily used as display in tab titles
 conduct_url = "" # optional + recommended: if omitted, the CoC checkboxes in /register will be hidden

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,5 +1,58 @@
 # Hosting
 
+## `CERCA_ROOT`
+
+By default certain paths are relative to where `cerca` executes. These are:
+
+* the css theme file that can be customized, `html/assets/theme.css`
+* the content files defined by `config.Documents`, which are in `content/` by default
+* the config file, called `cerca.toml` by default and can be defined with flag `--config`
+* the database, residing in `data/forum.db` by default and an be defined with flag `--data`
+
+In order to make these default assumptions more useful in different deployment environments,
+the environment variable `CERCA_ROOT`. When set, it defines a base path from which to resolve
+the above relative paths. 
+
+If any path (for example `Config.Document.About` is set to `/var/www/forum-content`) is an
+absolute path, or if flags `--config` and `--data` are set to non-default values, then those
+paths **will not** be joined with `CERCA_ROOT`.
+
+In normal operation, `CERCA_ROOT` should be the path to the directory storing the following
+files for a particular instance of a Cerca forum:
+
+```
+├── cerca.toml
+├── content
+│   ├── about.md
+│   ├── logo.html
+│   ├── registration-instructions.md
+│   └── rules.md
+├── data
+│   └── forum.db
+├── html
+│   └── assets
+│       └── theme.css
+```
+
+If you run multiple forum instances on the same machine, then it is likely you want to also set
+different values for the `CERCA_ROOT` to point to the correct forum instance.
+
+You can set the environment variable in many ways, including directly when executing `cerca`:
+
+```
+CERCA_ROOT="/var/www/forum-for-friends" cerca run --authkey CHANGEME
+```
+
+You can also set the equivalent value in the config:
+
+```
+[tooling]
+cerca_root = "/your/path"
+```
+
+If `CERCA_ROOT` and the config's `cerca_root` are both set, then the config file's `cerca_root`
+takes effect over the `CERCA_ROOT` environment variable.
+
 ## System user
 
 You can use a system user with no login:

--- a/server/server.go
+++ b/server/server.go
@@ -991,11 +991,7 @@ const ACCOUNT_DELETE_ROUTE = "/account/delete"
 // new CercaForum objects. Pass the result to http.Serve() with your choice
 // of net.Listener.
 func NewServer(sessionKey, dir string, config types.Config) (*CercaForum, error) {
-	// repeat from ./cmd/cerca that ensures the correct value of CERCA_ROOT is chosen
-	cercaRoot := util.GetEnvCercaRoot()
-	if cercaRoot != "" && config.Tooling.CercaRoot == "" {
-		config.Tooling.CercaRoot = cercaRoot
-	}
+	util.EnsureCercaRootSet(&config)
 	// note: this ensures the CERCA_ROOT is used if initialization has not happened via ./cmd/cerca
 	dir = config.JoinWithRoot(dir)
 	s := &CercaForum{

--- a/server/server.go
+++ b/server/server.go
@@ -964,11 +964,16 @@ type CercaForum struct {
 
 func (u *CercaForum) directory() string {
 	if u.Directory == "" {
-		dir, err := os.Getwd()
-		if err != nil {
-			log.Fatal(err)
+		cercaRoot := util.GetEnvCercaRoot()
+		if cercaRoot != "" {
+			u.Directory = util.JoinWithBase(cercaRoot, "CercaForum")
+		} else {
+			dir, err := os.Getwd()
+			if err != nil {
+				log.Fatal(err)
+			}
+			u.Directory = filepath.Join(dir, "CercaForum")
 		}
-		u.Directory = filepath.Join(dir, "CercaForum")
 	}
 	os.MkdirAll(u.Directory, 0755)
 	return u.Directory
@@ -986,6 +991,13 @@ const ACCOUNT_DELETE_ROUTE = "/account/delete"
 // new CercaForum objects. Pass the result to http.Serve() with your choice
 // of net.Listener.
 func NewServer(sessionKey, dir string, config types.Config) (*CercaForum, error) {
+	// repeat from ./cmd/cerca that ensures the correct value of CERCA_ROOT is chosen
+	cercaRoot := util.GetEnvCercaRoot()
+	if cercaRoot != "" && config.Tooling.CercaRoot == "" {
+		config.Tooling.CercaRoot = cercaRoot
+	}
+	// note: this ensures the CERCA_ROOT is used if initialization has not happened via ./cmd/cerca
+	dir = config.JoinWithRoot(dir)
 	s := &CercaForum{
 		ServeMux:  http.ServeMux{},
 		Directory: dir,

--- a/server/server.go
+++ b/server/server.go
@@ -1054,7 +1054,7 @@ func NewServer(sessionKey, dir string, config types.Config) (*CercaForum, error)
 	s.ServeMux.HandleFunc("/rss/", handler.RSSRoute)
 	s.ServeMux.HandleFunc("/rss.xml", handler.RSSRoute)
 
-	fileserver := http.FileServer(http.Dir("html/assets/"))
+	fileserver := http.FileServer(http.Dir(config.JoinWithRoot("html/assets/")))
 	s.ServeMux.Handle("/assets/", http.StripPrefix("/assets/", fileserver))
 
 	return s, nil

--- a/types/types.go
+++ b/types/types.go
@@ -2,9 +2,14 @@ package types
 
 import (
 	"path/filepath"
+	"log"
 )
 
 type Config struct {
+	Tooling struct {
+		CercaRoot   string `json:"cerca_root"`
+	} `json:"application"`
+
 	Community struct {
 		Name        string `json:"name"`
 		ConductLink string `json:"conduct_url"` // optional
@@ -28,18 +33,42 @@ type Config struct {
 // Ensure that, at the very least, default paths exist for each expected document path. Does not overwrite previously set values.
 func (c *Config) EnsureDefaultPaths() {
 	if c.Documents.AboutPath == "" {
-		c.Documents.AboutPath = filepath.Join("content", "about.md")
+		c.Documents.AboutPath = c.JoinWithRoot("content", "about.md")
 	}
 	if c.Documents.RegisterRulesPath == "" {
-		c.Documents.RegisterRulesPath = filepath.Join("content", "rules.md")
+		c.Documents.RegisterRulesPath = c.JoinWithRoot("content", "rules.md")
 	}
 	if c.Documents.RegistrationExplanationPath == "" {
-		c.Documents.RegistrationExplanationPath = filepath.Join("content", "registration-instructions.md")
+		c.Documents.RegistrationExplanationPath = c.JoinWithRoot("content", "registration-instructions.md")
 	}
 	if c.Documents.LogoPath == "" {
-		c.Documents.LogoPath = filepath.Join("content", "logo.html")
+		c.Documents.LogoPath = c.JoinWithRoot("content", "logo.html")
 	}
 }
+
+
+// JoinWithRoot takes into account whether `path` is absolute or not. If it is absolute, then just return the absolute
+// path joined as a single string instead.
+func (c *Config) JoinWithRoot(path ...string) string {
+	appRoot := c.Tooling.CercaRoot
+	if appRoot == "" {
+		appRoot = "./"
+	}
+	// inlined util.JoinWithBase because of import cycle
+	joinedPath := filepath.Join(path...)
+	if filepath.IsAbs(joinedPath) {
+		return joinedPath
+	}
+	var p []string
+	p = append(p, appRoot)
+	p = append(p, joinedPath)
+	finalPath, err := filepath.Abs(filepath.Join(p...))
+	if err != nil {
+		log.Fatalf("types.go (JoinWithRoot): %w\n", err)
+	}
+	return finalPath
+}
+
 
 /*
 config structure:

--- a/util/util.go
+++ b/util/util.go
@@ -74,6 +74,13 @@ func JoinWithBase(base string, path ...string) string {
 	return finalPath
 }
 
+func EnsureCercaRootSet(config *types.Config) {
+	cercaRoot := GetEnvCercaRoot()
+	if cercaRoot != "" && config.Tooling.CercaRoot == "" {
+		config.Tooling.CercaRoot = cercaRoot
+	}
+}
+
 // format all errors consistently, and provide context for the error using the string `msg`
 func Eout(err error, msg string, args ...interface{}) error {
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -59,6 +59,21 @@ func (ed ErrorDescriber) Check(err error, msg string, args ...interface{}) {
 	Check(err, msg, args...)
 }
 
+// returns `path` joined using os-dep separators if it is an absolute path, otherwise constructs a path
+// by joining `base` with `path`
+func JoinWithBase(base string, path ...string) string {
+	joinedPath := filepath.Join(path...)
+	if filepath.IsAbs(joinedPath) {
+		return joinedPath
+	}
+	var p []string
+	p = append(p, base)
+	p = append(p, joinedPath)
+	finalPath, err := filepath.Abs(filepath.Join(p...))
+	Check(err, "JoinWithBase abs(path)")
+	return finalPath
+}
+
 // format all errors consistently, and provide context for the error using the string `msg`
 func Eout(err error, msg string, args ...interface{}) error {
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -107,6 +107,16 @@ func Contains(slice []string, s string) bool {
 	return false
 }
 
+func GetEnvCercaRoot () string {
+	for _, env := range os.Environ() {
+		parts := strings.Split(env, "=")
+		if parts[0] == "CERCA_ROOT" {
+			return parts[1]
+		}
+	}
+	return ""
+}
+
 var contentGuardian = bluemonday.UGCPolicy()
 var strictContentGuardian = bluemonday.StrictPolicy()
 


### PR DESCRIPTION
from docs/hosting.md:

`CERCA_ROOT`

By default certain paths are relative to where `cerca` executes. These are:

* the css theme file that can be customized, `html/assets/theme.css`
* the content files defined by `config.Documents`, which are in `content/` by default
* the config file, called `cerca.toml` by default and can be defined with flag `--config`
* the database, residing in `data/forum.db` by default and an be defined with flag `--data`

In order to make these default assumptions more useful in different deployment environments, the environment variable `CERCA_ROOT`. When set, it defines a base path from which to resolve the above relative paths.

If any path (for example `Config.Document.About` is set to `/var/www/forum-content`) is an absolute path, or if flags `--config` and `--data` are set to non-default values, then those paths **will not** be joined with `CERCA_ROOT`.¨

closes #115 cc @decentral1se (btw i've not rigorously run this locally yet! just a quick build and execute)