### PR TITLE
Hide invite instructions when blank

### DIFF
--- a/html/register.html
+++ b/html/register.html
@@ -2,11 +2,13 @@
 <main>
     <h1> {{ "Register" | translate | capitalize }}</h1>
     {{ .Data.Rules }} <!-- registration rules will be inserted here from the rules document being read from the config -->
-    <details>
-        <summary> {{ "RegisterInviteInstructionsTitle" | translate }}</summary>
-        <!-- add your community's registration instructions by editing the registration-instructions document, see the config for where to find it!-->
-        {{ .Data.InviteInstructions }}
-    </details>
+    {{ if gt (len .Data.InviteInstructions) 0 }}
+        <details>
+            <summary> {{ "RegisterInviteInstructionsTitle" | translate }}</summary>
+            <!-- add your community's registration instructions by editing the registration-instructions document, see the config for where to find it!-->
+            {{ .Data.InviteInstructions }}
+        </details>
+    {{ end }}
 
     <form method="post">
         <label for="username">{{ "Username" | translate | capitalize }}:</label>


### PR DESCRIPTION
I put all my instructions in `rules.md`, so I want to hide the `<detail>`. Now, this can be done by making `registration-instructions.md` a blank file.