### PR TITLE
chore: ignore dev files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ admin-reset
 *.json
 /cerca
 cmd/cerca/cerca
+cerca-data/
+cerca.toml
+content/


### PR DESCRIPTION
When I run https://github.com/cblgh/cerca?tab=readme-ov-file#local-development I end up with the following unstaged dev files in my repository checkout. So, here's a `.gitignore` change to keep them off the Git radar.