### PR TITLE
feat: dockerfile

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.26-alpine AS build
+
+RUN apk add --no-cache \
+  gcc \
+  git \
+  musl-dev
+
+RUN git clone https://github.com/cblgh/cerca /build
+
+WORKDIR /build
+
+RUN CGO_ENABLED=1 go build -v ./cmd/cerca
+
+FROM alpine:3.22
+
+RUN apk add --no-cache bash
+
+COPY --from=build /build/cerca /usr/bin/cerca
+
+VOLUME /app
+
+RUN mkdir -p /app/data
+
+RUN /usr/bin/cerca write-defaults -config /app/cerca.toml -data-dir /app/data
+
+ENTRYPOINT ["/usr/bin/cerca", "-config", "/app/cerca.toml"]


### PR DESCRIPTION
On my way towards cooking up a cerca/rauthy test harness.

Maybe handy for others, if you want it, merge away. Otherwise, no stress.

```bash
cd contrib
docker build -t cblgh/cerca:dev . # build it
docker run -p 8272:8272 cblgh/cerca:dev # run it
docker run -ti --entrypoint="" cblgh/cerca:dev bash # shell in
```

All the default data gets set up in `/app`.

It's ~ 28 MB.

In a `compose.yml` setup with volume persistence, you can do:

```yaml
services:
  cerca:
    image: cblgh/cerca:dev
    volumes:
      - cerca-data:/app
```