### PR TITLE
Add Private RSS

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -149,6 +149,7 @@ func createTables(db *sql.DB) {
   `,
 
 		/* also known as forum categories; buckets of threads */
+		/* NOTE: this is unused. we use categories as [name in thread title] instead
 		`
   CREATE TABLE IF NOT EXISTS topics (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -169,6 +170,15 @@ func createTables(db *sql.DB) {
     FOREIGN KEY(authorid) REFERENCES users(id)
   );
   `,
+	`
+  CREATE TABLE IF NOT EXISTS apikeys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    apikey TEXT NOT NULL,
+    publishtime DATE,
+    userid INTEGER,
+    FOREIGN KEY(userid) REFERENCES users(id)
+  );
+		`,
 		`
   CREATE TABLE IF NOT EXISTS posts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -514,6 +524,51 @@ func (d DB) CheckUsernameExists(username string) (bool, error) {
 func (d DB) CheckThreadExists(threadid int) (bool, error) {
 	stmt := `SELECT 1 FROM threads WHERE id = ?`
 	return d.existsQuery(stmt, threadid)
+}
+
+func (d DB) CheckUserHasAPIKey(userid int) (bool, error) {
+	stmt := `SELECT 1 FROM apikeys WHERE userid = ?`
+	return d.existsQuery(stmt, userid)
+}
+
+func (d DB) CheckAPIKeyValid(apikey string) (bool, error) {
+	stmt := `SELECT 1 FROM apikeys WHERE apikey = ?`
+	return d.existsQuery(stmt, apikey)
+}
+
+func (d DB) GetAPIKey(userid int) string {
+	ed := eout.Describe("get api key")
+	exists, err := d.CheckUserHasAPIKey(userid)
+	ed.Check(err, "check api key exists")
+	if exists {
+		var apikey string
+		stmt := `SELECT apikey FROM apikeys WHERE userid = ?`
+		err := d.db.QueryRow(stmt, userid).Scan(&apikey)
+		ed.Check(err, "query row for existing key")
+		return apikey
+	}
+	// apikey doesn't appear to exist, let's create it!
+	return d.RefreshAPIKey(userid)
+}
+
+func (d DB) RefreshAPIKey(userid int) string {
+	ed := eout.Describe("set api key")
+	exists, err := d.CheckUserHasAPIKey(userid)
+	ed.Check(err, "check api key exists")
+	apikey := util.GetUUIDv4()
+	publishtime := time.Now()
+	// we create it
+	if !exists {
+		stmt := `INSERT INTO apikeys (apikey, publishtime, userid) VALUES (?, ?, ?)`
+		_, err := d.Exec(stmt, apikey, publishtime, userid)
+		ed.Check(err, "insert new key")
+	} else {
+	// otherwise we update it 
+		stmt := `UPDATE apikeys SET apikey = ?, publishtime = ? WHERE userid = ?`
+		_, err = d.Exec(stmt, apikey, publishtime, userid)
+		ed.Check(err, "update existing key")
+	}
+	return apikey
 }
 
 func (d DB) UpdateUsername(userid int, newname string) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gomod.cblgh.org/cerca
 
-go 1.21
+go 1.22
 
 toolchain go1.23.0
 

--- a/html/account.html
+++ b/html/account.html
@@ -9,6 +9,26 @@
     </div>
     {{ end }}
 
+    <h2>Private RSS feed</h2>
+    <p>This RSS feed is private to you and will let you subscribe to see when private threads have new posts or are
+    created. Please do not share it</p>
+
+    <form method="POST" action="{{ .Data.RefreshAPIKeyRoute }}">
+        <!-- <div> -->
+        <!--     <label for id="apikey">API Key</label> -->
+        <!--     <input type="text" readonly value="{{ .Data.APIKey }}"> -->
+        <!-- </div> -->
+        <div>
+            <a href="/rss/{{ .Data.APIKey }}">Copy this link and put it in your rss reader</a>
+        </div>
+        <p style="margin-top: 1rem;">Click the button below to generate a new link for your private RSS feed. This can be useful if you
+        accidentally shared it and want to inactivate that link.</p>
+        <div>
+            <input type="submit" value='Generate new RSS link'>
+        </div>
+    </form>
+    </section>
+
     <h2>Change password</h2>
 
     <form method="POST" action="{{ .Data.ChangePasswordRoute }}">

--- a/server/server.go
+++ b/server/server.go
@@ -90,7 +90,9 @@ type AccountData struct {
 	ChangePasswordRoute string
 	ChangeUsernameRoute string
 	DeleteAccountRoute  string
+	RefreshAPIKeyRoute string
 	LoggedInUsername    string
+	APIKey string
 }
 
 type LoginData struct {
@@ -117,6 +119,7 @@ type RequestHandler struct {
 	translator i18n.Translator
 	templates  *template.Template
 	rssFeed    string
+	privateRSSFeed string
 }
 
 var developing bool
@@ -361,8 +364,9 @@ func (h *RequestHandler) ThreadRoute(res http.ResponseWriter, req *http.Request)
 		}
 
 		newSlug := util.GetThreadSlug(threadid, posts[0].ThreadTitle, len(posts))
-		// update the rss feed
-		h.rssFeed = GenerateRSS(h.db, h.config)
+		// update the rss feed (public + private copy)
+		h.rssFeed = GenerateRSS(h.db, h.config, false)
+		h.privateRSSFeed = GenerateRSS(h.db, h.config, true) 
 		http.Redirect(res, req, newSlug, http.StatusFound)
 		return
 	}
@@ -498,14 +502,13 @@ func joinPath(host, upath string) string {
 	return fmt.Sprintf("%s/%s", host, upath)
 }
 
-func GenerateRSS(db *database.DB, config types.Config) string {
+func GenerateRSS(db *database.DB, config types.Config, includePrivateThreads bool) string {
 	if config.RSS.URL == "" {
 		return "feed not configured"
 	}
 	// TODO (2022-12-08): augment ListThreads to choose getting author of latest post or thread creator (currently latest
 	// post always)
 	sortByPost := true
-	includePrivateThreads := false
 	threads := db.ListThreads(sortByPost, includePrivateThreads)
 	entries := make([]string, len(threads))
 	for i, t := range threads {
@@ -535,6 +538,35 @@ func (h *RequestHandler) RSSRoute(res http.ResponseWriter, req *http.Request) {
 		dump(err)
 		http.Error(res, "An error occured", http.StatusInternalServerError)
 	}
+}
+
+func (h *RequestHandler) RSSPrivateRoute(res http.ResponseWriter, req *http.Request) {
+	// error if feed not configured (e.g. config.RSS.URL not set)
+	if h.config.RSS.URL == "" {
+		http.Error(res, "Feed Not Configured", http.StatusNotFound)
+		return
+	}
+	apikey := req.PathValue("apikey")
+	apiKeyValid, err := h.db.CheckAPIKeyValid(apikey)
+	if err != nil  {
+		dump(err)
+		http.Error(res, "An error occured", http.StatusInternalServerError)
+	}
+	if apiKeyValid {
+		// generate feed wasn't populated; generate it and include private threads
+		if len(h.privateRSSFeed) == 0 {
+			h.privateRSSFeed = GenerateRSS(h.db, h.config, true) 
+		}
+		res.Header().Set("Content-Type", "application/xml")
+		_, err = io.WriteString(res, h.privateRSSFeed)
+		if err != nil {
+			dump(err)
+			http.Error(res, "An error occured", http.StatusInternalServerError)
+		}
+		return
+	}
+	http.Error(res, "Your credentials are not valid to view the private RSS feed", http.StatusForbidden)
+	return
 }
 
 func (h RequestHandler) LogoutRoute(res http.ResponseWriter, req *http.Request) {
@@ -771,12 +803,25 @@ func (h RequestHandler) AboutRoute(res http.ResponseWriter, req *http.Request) {
 
 func (h RequestHandler) AccountRoute(res http.ResponseWriter, req *http.Request) {
 	loggedIn, userid := h.IsLoggedIn(req)
+	if !loggedIn {
+		title := h.translator.Translate("NotLoggedIn")
+		data := GenericMessageData{
+			Title:       title,
+			Message:     "You are not logged in",
+			Link:        "/login",
+			LinkMessage: "Log in to view the account page",
+			LinkText:    h.translator.Translate("LogIn"),
+		}
+		h.renderGenericMessage(res, req, data)
+		return
+	}
 	username, err := h.db.GetUsername(userid)
 	var errMessage string
 	if err != nil {
 		errMessage = "Could not get the username for the logged-in user"
 	}
-	h.renderView(res, "account", TemplateData{Data: AccountData{LoggedInUsername: username, ErrorMessage: errMessage, DeleteAccountRoute: ACCOUNT_DELETE_ROUTE, ChangeUsernameRoute: ACCOUNT_CHANGE_USERNAME_ROUTE, ChangePasswordRoute: ACCOUNT_CHANGE_PASSWORD_ROUTE}, HasRSS: h.config.RSS.URL != "", LoggedIn: loggedIn, Title: "Account"})
+	apikey := h.db.GetAPIKey(userid)
+	h.renderView(res, "account", TemplateData{Data: AccountData{APIKey: apikey, LoggedInUsername: username, ErrorMessage: errMessage, DeleteAccountRoute: ACCOUNT_DELETE_ROUTE, ChangeUsernameRoute: ACCOUNT_CHANGE_USERNAME_ROUTE, ChangePasswordRoute: ACCOUNT_CHANGE_PASSWORD_ROUTE, RefreshAPIKeyRoute: ACCOUNT_REFRESH_API_KEY_ROUTE}, HasRSS: h.config.RSS.URL != "", LoggedIn: loggedIn, Title: "Account"})
 }
 
 func (h RequestHandler) RobotsRoute(res http.ResponseWriter, req *http.Request) {
@@ -846,8 +891,9 @@ func (h *RequestHandler) NewThreadRoute(res http.ResponseWriter, req *http.Reque
 			h.renderGenericMessage(res, req, data)
 			return
 		}
-		// update the rss feed
-		h.rssFeed = GenerateRSS(h.db, h.config)
+		// update the rss feed (public version and private version)
+		h.rssFeed = GenerateRSS(h.db, h.config, false) // do not include private threads
+		h.privateRSSFeed = GenerateRSS(h.db, h.config, true) // include private threads
 		// when data has been stored => redirect to thread
 		slug := fmt.Sprintf("thread/%d/%s/", threadid, util.SanitizeURL(title))
 		http.Redirect(res, req, "/"+slug, http.StatusSeeOther)
@@ -907,7 +953,8 @@ func (h *RequestHandler) DeletePostRoute(res http.ResponseWriter, req *http.Requ
 			return
 		}
 		// update the rss feed, in case the deleted post was present in feed
-		h.rssFeed = GenerateRSS(h.db, h.config)
+		h.rssFeed = GenerateRSS(h.db, h.config, false) // exclude private threads
+		h.privateRSSFeed = GenerateRSS(h.db, h.config, true) // include private threads
 	}
 	http.Redirect(res, req, threadURL, http.StatusSeeOther)
 }
@@ -1008,6 +1055,7 @@ const INVITES_DELETE_ROUTE = "/invites/delete"
 const ACCOUNT_CHANGE_PASSWORD_ROUTE = "/account/change-password"
 const ACCOUNT_CHANGE_USERNAME_ROUTE = "/account/change-username"
 const ACCOUNT_DELETE_ROUTE = "/account/delete"
+const ACCOUNT_REFRESH_API_KEY_ROUTE = "/account/refresh-api-key"
 
 // NewServer sets up a new CercaForum object. Always use this to initialize
 // new CercaForum objects. Pass the result to http.Serve() with your choice
@@ -1050,8 +1098,9 @@ func NewServer(authKey string, dir string, config types.Config) (*CercaForum, er
 	// for currently translated languages, see i18n/i18n.go
 	translator := i18n.Init(config.General.Language)
 	templates := template.Must(generateTemplates(config, files, translator))
-	feed := GenerateRSS(&db, config)
-	handler := RequestHandler{&db, session.New(authKey, cookieName, developing), files, config, translator, templates, feed}
+	publicFeed := GenerateRSS(&db, config, false)
+	privateFeed := GenerateRSS(&db, config, true)
+	handler := RequestHandler{&db, session.New(authKey, cookieName, developing), files, config, translator, templates, publicFeed, privateFeed}
 
 	/* note: be careful with trailing slashes; go's default handler is a bit sensitive */
 	// TODO (2022-01-10): introduce middleware to make sure there is never an issue with trailing slashes
@@ -1068,6 +1117,7 @@ func NewServer(authKey string, dir string, config types.Config) (*CercaForum, er
 	s.ServeMux.HandleFunc("/proposal-veto", handler.VetoProposal)
 	s.ServeMux.HandleFunc("/proposal-confirm", handler.ConfirmProposal)
 	// self-service account changes a user can tend to on their own behalf
+	s.ServeMux.HandleFunc(ACCOUNT_REFRESH_API_KEY_ROUTE, handler.AccountRefreshAPIKey)
 	s.ServeMux.HandleFunc(ACCOUNT_CHANGE_PASSWORD_ROUTE, handler.AccountChangePassword)
 	s.ServeMux.HandleFunc(ACCOUNT_CHANGE_USERNAME_ROUTE, handler.AccountChangeUsername)
 	s.ServeMux.HandleFunc(ACCOUNT_DELETE_ROUTE, handler.AccountSelfServiceDelete)
@@ -1083,7 +1133,8 @@ func NewServer(authKey string, dir string, config types.Config) (*CercaForum, er
 	s.ServeMux.HandleFunc("/thread/", handler.ThreadRoute)
 	s.ServeMux.HandleFunc("/robots.txt", handler.RobotsRoute)
 	s.ServeMux.HandleFunc("/", handler.IndexRoute)
-	s.ServeMux.HandleFunc("/rss/", handler.RSSRoute)
+	s.ServeMux.HandleFunc("GET /rss/{apikey}", handler.RSSPrivateRoute)
+	s.ServeMux.HandleFunc("GET /rss/", handler.RSSRoute)
 	s.ServeMux.HandleFunc("/rss.xml", handler.RSSRoute)
 
 	fileserver := http.FileServer(http.Dir(assetsPath))


### PR DESCRIPTION
Back in December I'd worked on a feature to make a Private RSS feed (i.e. #70) available from /account for logged in users. Then forgotten all about it! Anyway here it is, rebased on-top of main.

The feature works by creating a new "api key" table in the database, and registering a new http route `/rss/{apikey}`. The old `/rss/` route is the same as it was previously i.e. public RSS. Users can refresh the RSS key if they accidentally leak it. The private RSS feed is also not tied to any other credentials. The API key is intentionally decoupled from RSS to potentially allow other shenanigans from advanced users in the future.

<img width="993" height="502" alt="image" src="https://github.com/user-attachments/assets/582782f2-97c5-42c8-b2fd-b9cab060314b" />

_img of /account after having refreshed the rss key_

cc @decentral1se good to know about! this should be pretty self-contained and not make it mega-hard to merge the rauthy bits